### PR TITLE
Do not run rules on non-Teraform directories

### DIFF
--- a/rules/terraform_required_version.go
+++ b/rules/terraform_required_version.go
@@ -48,6 +48,15 @@ func (r *TerraformRequiredVersionRule) Check(runner tflint.Runner) error {
 		return nil
 	}
 
+	files, err := runner.GetFiles()
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		// This rule does not run on non-Terraform directory.
+		return nil
+	}
+
 	body, err := runner.GetModuleContent(&hclext.BodySchema{
 		Blocks: []hclext.BlockSchema{
 			{

--- a/rules/terraform_required_version_test.go
+++ b/rules/terraform_required_version_test.go
@@ -13,6 +13,10 @@ func Test_TerraformRequiredVersionRule(t *testing.T) {
 		Expected helper.Issues
 	}{
 		{
+			Name:     "empty module",
+			Expected: helper.Issues{},
+		},
+		{
 			Name: "unset",
 			Content: `
 terraform {}
@@ -55,7 +59,11 @@ terraform {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			runner := helper.TestRunner(t, map[string]string{"module.tf": tc.Content})
+			files := map[string]string{}
+			if tc.Content != "" {
+				files = map[string]string{"module.tf": tc.Content}
+			}
+			runner := helper.TestRunner(t, files)
 
 			if err := rule.Check(runner); err != nil {
 				t.Fatal(err)

--- a/rules/terraform_standard_module_structure.go
+++ b/rules/terraform_standard_module_structure.go
@@ -57,6 +57,15 @@ func (r *TerraformStandardModuleStructureRule) Check(runner tflint.Runner) error
 		return nil
 	}
 
+	files, err := runner.GetFiles()
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		// This rule does not run on non-Terraform directory.
+		return nil
+	}
+
 	body, err := runner.GetModuleContent(&hclext.BodySchema{
 		Blocks: []hclext.BlockSchema{
 			{

--- a/rules/terraform_standard_module_structure_test.go
+++ b/rules/terraform_standard_module_structure_test.go
@@ -15,8 +15,15 @@ func Test_TerraformStandardModuleStructureRule(t *testing.T) {
 		Expected helper.Issues
 	}{
 		{
-			Name:    "empty module",
-			Content: map[string]string{},
+			Name:     "empty module",
+			Content:  map[string]string{},
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "non-standard module",
+			Content: map[string]string{
+				"foo.tf": "",
+			},
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformStandardModuleStructureRule(),


### PR DESCRIPTION
This PR changes `terraform_required_version` and `terraform_standard_module_structure` to only run if the module contains a tf file. Since these rules warn against "non-existence", they will also emit an issue for an empty module. However, this behavior is just misleading and should not be emitted for empty modules.
