### PR TITLE
Prefer --only option over other rules config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.19
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/google/go-cmp v0.5.8
+	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-getter v1.6.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.14.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
-	github.com/terraform-linters/tflint-plugin-sdk v0.12.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.13.0
 	github.com/zclconf/go-cty v1.11.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,9 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -176,8 +177,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/terraform-linters/tflint-plugin-sdk v0.12.0 h1:M++ZPQXIbcGKnI6KyQz3AblCkodoKIY/glheL43LTOU=
-github.com/terraform-linters/tflint-plugin-sdk v0.12.0/go.mod h1:/lXvT/LfKOWdjoQgtRbA8VSHtGr8RFwarPIDf20lXbc=
+github.com/terraform-linters/tflint-plugin-sdk v0.13.0 h1:aGRUMlN+m1dAGZ7vLPRrC71Esl8GMxC71Fce/RRv3i4=
+github.com/terraform-linters/tflint-plugin-sdk v0.13.0/go.mod h1:BWxrWRnzU+wQddNnsY4HGDEVBNLhVzQZZU8tCoRYxVI=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/terraform/ruleset_test.go
+++ b/terraform/ruleset_test.go
@@ -93,6 +93,14 @@ func TestApplyConfig(t *testing.T) {
 			},
 		},
 		{
+			name:   "only",
+			global: &tflint.Config{Only: []string{"terraform_deprecated_interpolation"}},
+			config: &hclext.BodyContent{},
+			want: []string{
+				"terraform_deprecated_interpolation",
+			},
+		},
+		{
 			name:   "disabled by default + preset",
 			global: &tflint.Config{DisabledByDefault: true},
 			config: &hclext.BodyContent{
@@ -122,6 +130,17 @@ func TestApplyConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "disabled by default + only",
+			global: &tflint.Config{
+				DisabledByDefault: true,
+				Only:              []string{"terraform_comment_syntax"},
+			},
+			config: &hclext.BodyContent{},
+			want: []string{
+				"terraform_comment_syntax",
+			},
+		},
+		{
 			name: "preset + rule config",
 			global: &tflint.Config{
 				Rules: map[string]*tflint.RuleConfig{
@@ -138,6 +157,37 @@ func TestApplyConfig(t *testing.T) {
 			},
 			want: []string{
 				"terraform_deprecated_index",
+			},
+		},
+		{
+			name: "preset + only",
+			global: &tflint.Config{
+				Only: []string{"terraform_deprecated_interpolation"},
+			},
+			config: &hclext.BodyContent{
+				Attributes: hclext.Attributes{
+					"preset": &hclext.Attribute{Name: "preset", Expr: mustParseExpr(`"recommended"`)},
+				},
+			},
+			want: []string{
+				"terraform_deprecated_interpolation",
+			},
+		},
+		{
+			name: "rule config + only",
+			global: &tflint.Config{
+				Rules: map[string]*tflint.RuleConfig{
+					"terraform_comment_syntax": {
+						Name:    "terraform_comment_syntax",
+						Enabled: false,
+					},
+				},
+				Only: []string{"terraform_comment_syntax", "terraform_deprecated_interpolation"},
+			},
+			config: &hclext.BodyContent{},
+			want: []string{
+				"terraform_comment_syntax",
+				"terraform_deprecated_interpolation",
 			},
 		},
 		{
@@ -158,6 +208,28 @@ func TestApplyConfig(t *testing.T) {
 			},
 			want: []string{
 				"terraform_deprecated_index",
+			},
+		},
+		{
+			name: "disabled by default + preset + rule config + only",
+			global: &tflint.Config{
+				Rules: map[string]*tflint.RuleConfig{
+					"terraform_comment_syntax": {
+						Name:    "terraform_comment_syntax",
+						Enabled: false,
+					},
+				},
+				DisabledByDefault: true,
+				Only:              []string{"terraform_comment_syntax", "terraform_deprecated_interpolation"},
+			},
+			config: &hclext.BodyContent{
+				Attributes: hclext.Attributes{
+					"preset": &hclext.Attribute{Name: "preset", Expr: mustParseExpr(`"recommended"`)},
+				},
+			},
+			want: []string{
+				"terraform_comment_syntax",
+				"terraform_deprecated_interpolation",
 			},
 		},
 	}


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/issues/1513
See https://github.com/terraform-linters/tflint-plugin-sdk/pull/198

This PR updates tflint-plugin-sdk version to fix the rules priority bug. Please note that TFLint v0.40.1+ is required to apply this bug fix.