### PR TITLE
`deprecated_index`: reject legacy splat expressions

### DIFF
--- a/docs/rules/terraform_deprecated_index.md
+++ b/docs/rules/terraform_deprecated_index.md
@@ -25,9 +25,30 @@ Warning: List items should be accessed using square brackets (terraform_deprecat
 Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_deprecated_index.md
 ```
 
+```hcl
+locals {
+  list  = [{a = "b}, {a = "c"}]
+  value = list.*.a 
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: List items should be accessed using square brackets (terraform_deprecated_index)
+
+  on example.tf line 3:
+   3:   value = list.*.a
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_deprecated_index.md
+```
+
 ## Why
 
-Terraform v0.12 supports traditional square brackets for accessing list items by index. However, for backward compatability with v0.11, Terraform continues to support accessing list items with the dot syntax normally used for attributes. While Terraform does not print warnings for this syntax, it is no longer documented and its use is discouraged.
+Terraform v0.12 supports traditional square brackets for accessing list items by index or using the splat operator (`*`). However, for backward compatibility with v0.11, Terraform continues to support accessing list items with the dot syntax normally used for attributes. While Terraform does not print warnings for this syntax, it is no longer documented and its use is discouraged.
+
+* [Legacy Splat Expressions](https://developer.hashicorp.com/terraform/language/expressions/splat#legacy-attribute-only-splat-expressions)
 
 ## How To Fix
 

--- a/rules/terraform_deprecated_index_test.go
+++ b/rules/terraform_deprecated_index_test.go
@@ -40,6 +40,32 @@ locals {
 			},
 		},
 		{
+			Name: "deprecated dot splat index style",
+			Content: `
+locals {
+  maplist = [{a = "b"}]
+  values = maplist.*.a
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedIndexRule(),
+					Message: "List items should be accessed using square brackets",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 12,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 23,
+						},
+					},
+				},
+			},
+		},
+		{
 			Name: "attribute access",
 			Content: `
 locals {


### PR DESCRIPTION
Detects splat expressions in addition to numeric indexes for legacy list access using the dot operator. Closes #20. 

I found that an `hcl.Traversal` doesn't account for the splat operator at all. So rather than trying to detect that a traversal is a specific type (`hcl.TraverseIndex`), I've modified the logic to purely depend on the lexed tokens from the expression. The first token is discarded. Then the rule iterates through the tokens. If a dot is followed by either a number literal or star, an issue is emitted.