### PR TITLE
`terraform_deprecated_index`: handle Terraform directives (HCL template)

### DIFF
--- a/rules/terraform_deprecated_index.go
+++ b/rules/terraform_deprecated_index.go
@@ -66,6 +66,8 @@ func (r *TerraformDeprecatedIndexRule) Check(runner tflint.Runner) error {
 
 			tokens, diags := hclsyntax.LexExpression(bytes, filename, variable.SourceRange().Start)
 			if diags.HasErrors() {
+				// HACK: If the expression cannot be lexed, try to lex it as a template.
+				// If it still cannot be lexed, return the original error.
 				tTokens, tDiags := hclsyntax.LexTemplate(bytes, filename, variable.SourceRange().Start)
 				if tDiags.HasErrors() {
 					return diags

--- a/rules/terraform_deprecated_index.go
+++ b/rules/terraform_deprecated_index.go
@@ -66,7 +66,12 @@ func (r *TerraformDeprecatedIndexRule) Check(runner tflint.Runner) error {
 
 			tokens, diags := hclsyntax.LexExpression(bytes, filename, variable.SourceRange().Start)
 			if diags.HasErrors() {
-				return diags
+				tTokens, tDiags := hclsyntax.LexTemplate(bytes, filename, variable.SourceRange().Start)
+				if tDiags.HasErrors() {
+					return diags
+				}
+
+				tokens = tTokens
 			}
 
 			tokens = tokens[1:]

--- a/rules/terraform_deprecated_index_test.go
+++ b/rules/terraform_deprecated_index_test.go
@@ -84,6 +84,48 @@ locals {
 `,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "directive: valid",
+			Content: `
+locals {
+  servers = <<EOF
+%{ for ip in aws_instance.example[*].private_ip }
+server ${ip}
+%{ endfor }
+EOF
+}
+`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "directive: invalid",
+			Content: `
+		locals {
+		  servers = <<EOF
+		%{ for ip in aws_instance.example.*.private_ip }
+		server ${ip}
+		%{ endfor }
+		EOF
+		}
+		`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedIndexRule(),
+					Message: "List items should be accessed using square brackets",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 16,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 49,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	rule := NewTerraformDeprecatedIndexRule()


### PR DESCRIPTION
This handles [Terraform directives](https://developer.hashicorp.com/terraform/language/expressions/strings#directives) when lexing expressions to detect legacy splat expressions. Previously, as a result of #34, users would encounter an error if they had a Terraform directive. In order to detect splat expressions, #34 had to parse more expressions than before.

Turns out, directives are built on HCL templates. Using `LexTemplate` on these expressions works. It not only fixes the bug for unrelated directives, but also now catches use of legacy splat expressions in directives. Incidentally, [Terraform's official directive documentation](https://developer.hashicorp.com/terraform/language/expressions/splat) uses a legacy splat expression, which I'll also open a PR to fix 🙂 

The logic here of "try to lex as an expression, then as template" is a bit of a hack, which I've noted in a comment. The different expression types are:

* `*hclsyntax.TemplateExpr`
* `*hclsyntax.TemplateJoinExpr`
* `*hclsyntax.ForExpr`

So this also works:

```go
var tokens hclsyntax.Tokens
var diags hcl.Diagnostics

switch expr.(type) {
case *hclsyntax.TemplateExpr, *hclsyntax.TemplateJoinExpr, *hclsyntax.ForExpr:
	tokens, diags = hclsyntax.LexTemplate(bytes, filename, variable.SourceRange().Start)
default:
	tokens, diags = hclsyntax.LexExpression(bytes, filename, variable.SourceRange().Start)
}

if diags.HasErrors() {
	return diags
}
```

This is potentially more brittle though. `hclsyntax` seems happy to lex a for expression like this via `LexTemplate`:

```tf
locals {
  ips = [for ip in aws_instance.example[*].private_ip : ip]
}
```

I couldn't find anything in Terraform's codebase about how this is handled.

Closes #42 