### PR TITLE
`terraform_deprecated_index`: improve perf for files with many expressions

### DIFF
--- a/rules/terraform_deprecated_index.go
+++ b/rules/terraform_deprecated_index.go
@@ -48,27 +48,15 @@ func (r *TerraformDeprecatedIndexRule) Check(runner tflint.Runner) error {
 		return nil
 	}
 
-	files := map[string]*hcl.File{}
+	files, err := runner.GetFiles()
+	if err != nil {
+		return err
+	}
 
 	diags := runner.WalkExpressions(tflint.ExprWalkFunc(func(expr hcl.Expression) hcl.Diagnostics {
 		for _, variable := range expr.Variables() {
 			filename := expr.Range().Filename
-			file, ok := files[filename]
-
-			if !ok {
-				file, err = runner.GetFile(filename)
-				if err != nil {
-					return hcl.Diagnostics{
-						{
-							Severity: hcl.DiagError,
-							Summary:  "failed to call GetFile()",
-							Detail:   err.Error(),
-						},
-					}
-				}
-
-				files[filename] = file
-			}
+			file := files[filename]
 
 			bytes := expr.Range().SliceBytes(file.Bytes)
 

--- a/rules/terraform_deprecated_index_test.go
+++ b/rules/terraform_deprecated_index_test.go
@@ -1,6 +1,9 @@
 package rules
 
 import (
+	"bytes"
+	"fmt"
+	"html/template"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -139,6 +142,76 @@ EOF
 			}
 
 			helper.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}
+
+func BenchmarkTerraformDeprecatedInterpolation(b *testing.B) {
+	cases := []struct {
+		Size    int
+		Content string
+	}{
+		{
+			Size: 10,
+		},
+		{
+			Size: 100,
+		},
+		{
+			Size: 1000,
+		},
+		// {
+		// 	Size: 10000,
+		// },
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		// Generate a list of n objects as locals, where each has keys a-z
+		// and values 0-n
+		ct, err := template.New("test").Parse(`
+				locals {
+					alphas = [
+						{{- range .Size }}
+							{
+								{{- range $i, $c := $.Alpha }}
+								{{ $c }} = {{ $i }},
+								{{- end }}
+							},
+						{{- end }}
+					]
+				}`)
+
+		if err != nil {
+			b.Fatalf("Error rendering content template: %v", err)
+		}
+
+		buf := bytes.Buffer{}
+
+		err = ct.Execute(&buf, struct {
+			Size  []struct{}
+			Alpha []string
+		}{
+			Size:  make([]struct{}, tc.Size),
+			Alpha: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"},
+		})
+
+		if err != nil {
+			b.Fatalf("Error executing content template: %v", err)
+		}
+
+		tc.Content = buf.String()
+
+		b.Run(fmt.Sprintf("size=%d", tc.Size), func(b *testing.B) {
+			rule := NewTerraformDeprecatedIndexRule()
+			runner := helper.TestRunner(b, map[string]string{"config.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				b.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssues(b, helper.Issues{}, runner.Issues)
 		})
 	}
 }


### PR DESCRIPTION
A coworker at @observeinc alerted me to a module where new versions of TFLint were running extremely slowly. Some initial investigation revealed that `terraform_deprecated_index` was spending a really long time when there were a very large number of expressions to walk in a module. In this case, there were a few large JSON objects being encoded with `jsonencode` and all the key/value pairs are expressions, though mostly static.

```sh
# times out
tflint --only terraform_deprecated_index
```

Most of that time was going into repeatedly calling `runner.GetFile()`, which in the example case was being called hundreds of times for the same file. There's no parser instance stored on the runner so each `GetFile` call meant the file was read from disk and parsed as HCL.

Since `WalkExpressions` calls `GetFiles()` anyway, calling it once before walking is a straightforward fix that brings the performance to an acceptable point. In the module in question, previously TFLint ran for multiple minutes on my Mac Studio at 200% CPU before I'd give up after 5m and interrupt it before it printed any output. After, it finishes in ~8s. Caching files after load would probably further boost performance by avoiding multiple rounds of loading from disk and parsing. The memory penalty would probably be worthwhile for the reduced CPU usage.