### PR TITLE
Use # comment syntax in configuration example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ Here's an example:
 
 ```hcl
 plugin "terraform" {
-    // Plugin common attributes
+    # Plugin common attributes
 
     preset = "recommended"
 }


### PR DESCRIPTION
Updates the example config for the ruleset to use the [default commenting style](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_comment_syntax.md).