### PR TITLE
`required_providers`: use required provider entry as range if present

### DIFF
--- a/rules/terraform_required_providers.go
+++ b/rules/terraform_required_providers.go
@@ -129,7 +129,7 @@ func (r *TerraformRequiredProvidersRule) Check(rr tflint.Runner) error {
 			continue
 		}
 
-		provider, exists := requiredProviders[name]
+		requiredProvider, exists := requiredProviders[name]
 		if !exists {
 			if err := runner.EmitIssue(r, fmt.Sprintf(`Missing version constraint for provider "%s" in "required_providers"`, name), ref.DefRange); err != nil {
 				return err
@@ -137,7 +137,7 @@ func (r *TerraformRequiredProvidersRule) Check(rr tflint.Runner) error {
 			continue
 		}
 
-		val, diags := provider.Expr.Value(&hcl.EvalContext{
+		val, diags := requiredProvider.Expr.Value(&hcl.EvalContext{
 			Variables: map[string]cty.Value{
 				// configuration_aliases can declare additional provider instances
 				// required provider "foo" could have: configuration_aliases = [foo.a, foo.b]
@@ -166,7 +166,7 @@ func (r *TerraformRequiredProvidersRule) Check(rr tflint.Runner) error {
 					continue
 				}
 			}
-			if err := runner.EmitIssue(r, fmt.Sprintf(`Missing version constraint for provider "%s" in "required_providers"`, name), ref.DefRange); err != nil {
+			if err := runner.EmitIssue(r, fmt.Sprintf(`Missing version constraint for provider "%s" in "required_providers"`, name), requiredProvider.Expr.Range()); err != nil {
 				return err
 			}
 		}

--- a/rules/terraform_required_providers_test.go
+++ b/rules/terraform_required_providers_test.go
@@ -133,12 +133,12 @@ provider "template" {}
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
-							Line:   10,
-							Column: 1,
+							Line:   4,
+							Column: 14,
 						},
 						End: hcl.Pos{
-							Line:   10,
-							Column: 20,
+							Line:   6,
+							Column: 4,
 						},
 					},
 				},


### PR DESCRIPTION
When `required_providers` contains an entry for a given provider but includes only the `source` and not the `version` (or is an empty object), set the range for the issue to the range of the required provider entry. Previously, the range was the first reference to the provider.

Closes #61 