### PR TITLE
required_providers: warn on legacy version syntax, missing source

### DIFF
--- a/docs/rules/terraform_required_providers.md
+++ b/docs/rules/terraform_required_providers.md
@@ -1,6 +1,6 @@
 # terraform_required_providers
 
-Require that all providers have version constraints through `required_providers`.
+Require that all providers specify a `source` and `version` constraint through `required_providers`.
 
 > This rule is enabled by "recommended" preset.
 
@@ -22,7 +22,7 @@ provider "template" {}
 $ tflint
 1 issue(s) found:
 
-Warning: Missing version constraint for provider "template" in "required_providers" (terraform_required_providers)
+Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)
 
   on main.tf line 1:
    1: provider "template" {}
@@ -49,10 +49,88 @@ Warning: provider.template: version constraint should be specified via "required
 
 Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_required_providers.md
 
-Warning: Missing version constraint for provider "template" in "required_providers" (terraform_required_providers)
+Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)
 
   on main.tf line 1:
    1: provider "template" {
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_required_providers.md
+```
+
+<hr>
+
+```hcl
+provider "template" {}
+
+terraform {
+  required_providers {
+    template = "~> 2"
+  }
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: Legacy version constraint for provider "template" in `required_providers` (terraform_required_providers)
+
+  on main.tf line 5:
+   5:     template = "~> 2"
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_required_providers.md
+```
+
+<hr>
+
+```hcl
+provider "template" {}
+
+terraform {
+  required_providers {
+    template = {
+      version = "~> 2"
+    }
+  }
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: Legacy version constraint for provider "template" in `required_providers` (terraform_required_providers)
+
+  on main.tf line 5:
+   5:     template = "~> 2"
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_required_providers.md
+```
+
+<hr>
+
+```hcl
+provider "template" {}
+
+terraform {
+  required_providers {
+    template = {
+      version = "~> 2"
+    }
+  }
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: Missing `source` for provider "template" in `required_providers` (terraform_required_providers)
+
+  on main.tf line 5:
+   5:     template = {
+   6:       version = "~> 2"
+   7:     }
 
 Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_required_providers.md
 ```
@@ -61,16 +139,21 @@ Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0
 
 Providers are plugins released on a separate rhythm from Terraform itself, and so they have their own version numbers. For production use, you should constrain the acceptable provider versions via configuration, to ensure that new versions with breaking changes will not be automatically installed by `terraform init` in future.
 
+Terraform supports multiple provider registries/namespaces through the [`source` address](https://developer.hashicorp.com/terraform/language/providers/requirements#source-addresses) attribute. While this is optional for providers in `registry.terraform.io` under the `hashicorp` namespace (the defaults), it is required for all other providers. Omitting `source` is a common error when using third-party providers and using explicit source addresses for all providers is recommended.
+
 ## How To Fix
 
-Add the [`required_providers`](https://www.terraform.io/docs/configuration/terraform.html#specifying-required-provider-versions) block to the `terraform` configuration block and include current versions for all providers. For example:
+Add the [`required_providers`](https://developer.hashicorp.com/terraform/language/providers/requirements#requiring-providers) block to the `terraform` configuration block and include current versions for all providers. For example:
 
 ```tf
 terraform {
   required_providers {
-    template = "~> 2.0"
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2"
+    }
   }
 }
 ```
 
-Provider version constraints can be specified using a [version argument within a provider block](https://www.terraform.io/docs/configuration/providers.html#provider-versions) for backwards compatability. This approach is now discouraged, particularly for child modules.
+Provider version constraints can be specified using a [version argument within a provider block](https://www.terraform.io/docs/configuration/providers.html#provider-versions) for backwards compatibility. This approach is now discouraged, particularly for child modules.

--- a/docs/rules/terraform_required_providers.md
+++ b/docs/rules/terraform_required_providers.md
@@ -64,30 +64,6 @@ provider "template" {}
 
 terraform {
   required_providers {
-    template = "~> 2"
-  }
-}
-```
-
-```
-$ tflint
-1 issue(s) found:
-
-Warning: Legacy version constraint for provider "template" in `required_providers` (terraform_required_providers)
-
-  on main.tf line 5:
-   5:     template = "~> 2"
-
-Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_required_providers.md
-```
-
-<hr>
-
-```hcl
-provider "template" {}
-
-terraform {
-  required_providers {
     template = {
       version = "~> 2"
     }

--- a/docs/rules/terraform_required_providers.md
+++ b/docs/rules/terraform_required_providers.md
@@ -9,6 +9,10 @@ Require that all providers specify a `source` and `version` constraint through `
 ```hcl
 rule "terraform_required_providers" {
   enabled = true
+
+  # defaults
+  source = true
+  version = true
 }
 ```
 
@@ -133,3 +137,5 @@ terraform {
 ```
 
 Provider version constraints can be specified using a [version argument within a provider block](https://www.terraform.io/docs/configuration/providers.html#provider-versions) for backwards compatibility. This approach is now discouraged, particularly for child modules.
+
+Optionally, you can disable enforcement of either `source` or `version` by setting the corresponding attribute in the rule configuration to `false`.

--- a/rules/terraform_required_providers_test.go
+++ b/rules/terraform_required_providers_test.go
@@ -21,7 +21,7 @@ provider "template" {}
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Missing version constraint for provider "template" in "required_providers"`,
+					Message: "Missing version constraint for provider \"template\" in `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -46,7 +46,7 @@ resource "random_string" "foo" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Missing version constraint for provider "random" in "required_providers"`,
+					Message: "Missing version constraint for provider \"random\" in `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -71,7 +71,7 @@ data "template_file" "foo" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Missing version constraint for provider "template" in "required_providers"`,
+					Message: "Missing version constraint for provider \"template\" in `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -102,16 +102,32 @@ provider "template" {}
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "required_providers string",
+			Name: "legacy required_providers string",
 			Content: `
 terraform {
 	required_providers {
-		template = "~> 2" 
+		template = "~> 2"
 	}
 }
 provider "template" {} 
 `,
-			Expected: helper.Issues{},
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: "Legacy version constraint for provider \"template\" in `required_providers`",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 14,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 20,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "required_providers object missing version",
@@ -129,7 +145,7 @@ provider "template" {}
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Missing version constraint for provider "template" in "required_providers"`,
+					Message: "Missing version constraint for provider \"template\" in `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -145,6 +161,81 @@ provider "template" {}
 			},
 		},
 		{
+			Name: "required_providers object missing source",
+			Content: `
+terraform {
+	required_providers {
+		template = {
+			version = "~> 2"
+		}
+	}
+}
+
+provider "template" {} 
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: "Missing `source` for provider \"template\" in `required_providers`",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 14,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 4,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "required_providers empty object",
+			Content: `
+terraform {
+	required_providers {
+		template = {}
+	}
+}
+
+provider "template" {} 
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: "Missing `source` for provider \"template\" in `required_providers`",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 14,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 16,
+						},
+					},
+				},
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: "Missing version constraint for provider \"template\" in `required_providers`",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 14,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 16,
+						},
+					},
+				},
+			},
+		},
+		{
 			Name: "single provider with alias",
 			Content: `
 provider "template" {
@@ -154,7 +245,7 @@ provider "template" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Missing version constraint for provider "template" in "required_providers"`,
+					Message: "Missing version constraint for provider \"template\" in `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -188,7 +279,7 @@ provider "template" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `provider version constraint should be specified via "required_providers"`,
+					Message: "provider version constraint should be specified via `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -242,7 +333,7 @@ provider "template" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `provider version constraint should be specified via "required_providers"`,
+					Message: "provider version constraint should be specified via `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -295,7 +386,7 @@ resource "google_compute_instance" "foo" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Missing version constraint for provider "google-beta" in "required_providers"`,
+					Message: "Missing version constraint for provider \"google-beta\" in `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -327,7 +418,7 @@ resource "google_compute_instance" "foo" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Missing version constraint for provider "google-beta" in "required_providers"`,
+					Message: "Missing version constraint for provider \"google-beta\" in `required_providers`",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{


### PR DESCRIPTION
Tightens enforcement of `required_providers`:

* Rejects the legacy string syntax from Terraform 0.12.25 and earlier in favor of the object syntax which includes a `source`
* Enforces that `source` is defined with the object syntax

This is a breaking change, since previously these legacy syntaxes were accepted. It seems appropriate to focus on enforcement for modern TF versions and stop accommodating old/unsupported TF versions. While omitting a version constraint can lead to major issues down the road, omitting `source` is also a common hazard, albeit more of an immediate one. 

https://developer.hashicorp.com/terraform/language/providers/requirements#source-addresses

> If you omit the source argument..., Terraform uses an implied source address... This is a backward compatibility feature... in modules that require 0.13 or later, we recommend using explicit source addresses for all providers.

Closes #62 