### PR TITLE
terraform_deprecated_index: Emit issues based on expression types

### DIFF
--- a/rules/terraform_deprecated_index_test.go
+++ b/rules/terraform_deprecated_index_test.go
@@ -29,7 +29,7 @@ locals {
 						Filename: "config.tf",
 						Start: hcl.Pos{
 							Line:   4,
-							Column: 11,
+							Column: 15,
 						},
 						End: hcl.Pos{
 							Line:   4,
@@ -55,11 +55,11 @@ locals {
 						Filename: "config.tf",
 						Start: hcl.Pos{
 							Line:   4,
-							Column: 12,
+							Column: 19,
 						},
 						End: hcl.Pos{
 							Line:   4,
-							Column: 23,
+							Column: 21,
 						},
 					},
 				},
@@ -116,11 +116,78 @@ EOF
 						Filename: "config.tf",
 						Start: hcl.Pos{
 							Line:   4,
-							Column: 16,
+							Column: 36,
 						},
 						End: hcl.Pos{
 							Line:   4,
-							Column: 49,
+							Column: 38,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "legacy splat and legacy index",
+			Content: `
+locals {
+  nested_list = [["a"]]
+  value = nested_list.*.0
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedIndexRule(),
+					Message: "List items should be accessed using square brackets",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 22,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 24,
+						},
+					},
+				},
+				{
+					Rule:    NewTerraformDeprecatedIndexRule(),
+					Message: "List items should be accessed using square brackets",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 24,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 26,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "complex expression",
+			Content: `
+locals {
+  create_namespace = true
+  kubernetes_namespace = local.create_namespace ? join("", kubernetes_namespace.default.*.id) : var.kubernetes_namespace
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedIndexRule(),
+					Message: "List items should be accessed using square brackets",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 88,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 90,
 						},
 					},
 				},


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-terraform/issues/84

The current deprecated index detection is based on lexical analysis. Since the rule lexes every expression walked by `WalkExpressions`, it has the problem of emitting multiple issues for the same expression when walking on nested expressions.

This PR switches deprecated index detection from lexical analysis-based to syntax analysis-based. Instead of lexing the walked expression, depending on the expression type, check if it has deprecated indexes.

[hcl-parse](https://github.com/terraform-linters/hcl-parse) tells us that the types of expressions we should be dealing with in this rule are `ScopeTraversalExpr`, `RelativeTraversalExpr`, and `SplatExpr`.

```console
$ hcl-parse -e "list.0"
(*hclsyntax.ScopeTraversalExpr "list.0")

$ hcl-parse -e "map.*"
(*hclsyntax.SplatExpr
  (*hclsyntax.ScopeTraversalExpr "map")
  (*hclsyntax.AnonSymbolExpr)
)

$ hcl-parse -e "nested_list.*.0"
(*hclsyntax.SplatExpr
  (*hclsyntax.ScopeTraversalExpr "nested_list")
  (*hclsyntax.RelativeTraversalExpr ".0"
    (*hclsyntax.AnonSymbolExpr)
  )
)
```

This allows the rule to emit only one issue for nested expressions. Additionally, issues can be reported against a more precise range.