### PR TITLE
Add autofix support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.16.2
 	github.com/hashicorp/terraform-registry-address v0.2.0
-	github.com/terraform-linters/tflint-plugin-sdk v0.16.1
+	github.com/terraform-linters/tflint-plugin-sdk v0.16.2-0.20230605170513-64de942491dc
 	github.com/zclconf/go-cty v1.13.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/terraform-linters/tflint-plugin-sdk v0.16.1 h1:fBfLL8KzP3pkQrNp3iQxaGoKBoMo2sFYoqmhuo6yc+A=
-github.com/terraform-linters/tflint-plugin-sdk v0.16.1/go.mod h1:ltxVy04PRwptL6P/Ugz2ZeTNclYapClrLn/kVFXJGzo=
+github.com/terraform-linters/tflint-plugin-sdk v0.16.2-0.20230605170513-64de942491dc h1:z0PQWOWfWOYps2Oo7nT/v9XASazFZITnMA+oGWZzB78=
+github.com/terraform-linters/tflint-plugin-sdk v0.16.2-0.20230605170513-64de942491dc/go.mod h1:ltxVy04PRwptL6P/Ugz2ZeTNclYapClrLn/kVFXJGzo=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=

--- a/rules/terraform_comment_syntax.go
+++ b/rules/terraform_comment_syntax.go
@@ -79,10 +79,13 @@ func (r *TerraformCommentSyntaxRule) checkComments(runner tflint.Runner, filenam
 		}
 
 		if strings.HasPrefix(string(token.Bytes), "//") {
-			if err := runner.EmitIssue(
+			if err := runner.EmitIssueWithFix(
 				r,
 				"Single line comments should begin with #",
 				token.Range,
+				func(f tflint.Fixer) error {
+					return f.ReplaceText(f.RangeTo("//", filename, token.Range.Start), "#")
+				},
 			); err != nil {
 				return err
 			}

--- a/rules/terraform_comment_syntax_test.go
+++ b/rules/terraform_comment_syntax_test.go
@@ -13,6 +13,7 @@ func Test_TerraformCommentSyntaxRule(t *testing.T) {
 		Content  string
 		JSON     bool
 		Expected helper.Issues
+		Fixed    string
 	}{
 		{
 			Name:     "hash comment",
@@ -48,6 +49,7 @@ func Test_TerraformCommentSyntaxRule(t *testing.T) {
 					},
 				},
 			},
+			Fixed: `# foo`,
 		},
 		{
 			Name: "end-of-line hash comment",
@@ -82,6 +84,11 @@ variable "foo" {
 			}
 
 			helper.AssertIssues(t, tc.Expected, runner.Issues)
+			want := map[string]string{}
+			if tc.Fixed != "" {
+				want[filename] = tc.Fixed
+			}
+			helper.AssertChanges(t, want, runner.Changes())
 		})
 	}
 }

--- a/rules/terraform_deprecated_interpolation_test.go
+++ b/rules/terraform_deprecated_interpolation_test.go
@@ -12,94 +12,13 @@ func Test_TerraformDeprecatedInterpolationRule(t *testing.T) {
 		Name     string
 		Content  string
 		Expected helper.Issues
+		Fixed    string
 	}{
 		{
 			Name: "deprecated single interpolation",
 			Content: `
 resource "null_resource" "a" {
-	triggers = "${var.triggers}"
-}`,
-			Expected: helper.Issues{
-				{
-					Rule:    NewTerraformDeprecatedInterpolationRule(),
-					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
-					Range: hcl.Range{
-						Filename: "config.tf",
-						Start:    hcl.Pos{Line: 3, Column: 13},
-						End:      hcl.Pos{Line: 3, Column: 30},
-					},
-				},
-			},
-		},
-		{
-			Name: "deprecated single interpolation in provider block",
-			Content: `
-provider "null" {
-	foo = "${var.triggers["foo"]}"
-}`,
-			Expected: helper.Issues{
-				{
-					Rule:    NewTerraformDeprecatedInterpolationRule(),
-					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
-					Range: hcl.Range{
-						Filename: "config.tf",
-						Start:    hcl.Pos{Line: 3, Column: 8},
-						End:      hcl.Pos{Line: 3, Column: 32},
-					},
-				},
-			},
-		},
-		{
-			Name: "deprecated single interpolation in locals block",
-			Content: `
-locals {
-	foo = "${var.triggers["foo"]}"
-}`,
-			Expected: helper.Issues{
-				{
-					Rule:    NewTerraformDeprecatedInterpolationRule(),
-					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
-					Range: hcl.Range{
-						Filename: "config.tf",
-						Start:    hcl.Pos{Line: 3, Column: 8},
-						End:      hcl.Pos{Line: 3, Column: 32},
-					},
-				},
-			},
-		},
-		{
-			Name: "deprecated single interpolation in nested block",
-			Content: `
-resource "null_resource" "a" {
-	provisioner "local-exec" {
-		single = "${var.triggers["greeting"]}"
-	}
-}`,
-			Expected: helper.Issues{
-				{
-					Rule:    NewTerraformDeprecatedInterpolationRule(),
-					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
-					Range: hcl.Range{
-						Filename: "config.tf",
-						Start:    hcl.Pos{Line: 4, Column: 12},
-						End:      hcl.Pos{Line: 4, Column: 41},
-					},
-				},
-			},
-		},
-		{
-			Name: "interpolation as template",
-			Content: `
-resource "null_resource" "a" {
-	triggers = "${var.triggers} "
-}`,
-			Expected: helper.Issues{},
-		},
-		{
-			Name: "interpolation in array",
-			Content: `
-resource "null_resource" "a" {
-	triggers = ["${var.triggers}"]
+  triggers = "${var.triggers}"
 }`,
 			Expected: helper.Issues{
 				{
@@ -112,14 +31,149 @@ resource "null_resource" "a" {
 					},
 				},
 			},
+			Fixed: `
+resource "null_resource" "a" {
+  triggers = var.triggers
+}`,
+		},
+		{
+			Name: "deprecated single interpolation in provider block",
+			Content: `
+provider "null" {
+  foo = "${var.triggers["foo"]}"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9},
+						End:      hcl.Pos{Line: 3, Column: 33},
+					},
+				},
+			},
+			Fixed: `
+provider "null" {
+  foo = var.triggers["foo"]
+}`,
+		},
+		{
+			Name: "deprecated single interpolation in locals block",
+			Content: `
+locals {
+  foo = "${var.triggers["foo"]}"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9},
+						End:      hcl.Pos{Line: 3, Column: 33},
+					},
+				},
+			},
+			Fixed: `
+locals {
+  foo = var.triggers["foo"]
+}`,
+		},
+		{
+			Name: "deprecated single interpolation in nested block",
+			Content: `
+resource "null_resource" "a" {
+  provisioner "local-exec" {
+    single = "${var.triggers["greeting"]}"
+  }
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 4, Column: 14},
+						End:      hcl.Pos{Line: 4, Column: 43},
+					},
+				},
+			},
+			Fixed: `
+resource "null_resource" "a" {
+  provisioner "local-exec" {
+    single = var.triggers["greeting"]
+  }
+}`,
+		},
+		{
+			Name: "interpolation as template",
+			Content: `
+resource "null_resource" "a" {
+  triggers = "${var.triggers} "
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "interpolation in array",
+			Content: `
+resource "null_resource" "a" {
+  triggers = ["${var.triggers}"]
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 15},
+						End:      hcl.Pos{Line: 3, Column: 32},
+					},
+				},
+			},
+			Fixed: `
+resource "null_resource" "a" {
+  triggers = [var.triggers]
+}`,
 		},
 		{
 			Name: "new interpolation syntax",
 			Content: `
 resource "null_resource" "a" {
-	triggers = var.triggers
+  triggers = var.triggers
 }`,
 			Expected: helper.Issues{},
+		},
+		{
+			Name: "nested wraps",
+			Content: `
+resource "null_resource" "a" {
+  triggers = "${"${var.triggers}"}"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 14},
+						End:      hcl.Pos{Line: 3, Column: 36},
+					},
+				},
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 17},
+						End:      hcl.Pos{Line: 3, Column: 34},
+					},
+				},
+			},
+			Fixed: `
+resource "null_resource" "a" {
+  triggers = var.triggers
+}`,
 		},
 	}
 
@@ -134,6 +188,11 @@ resource "null_resource" "a" {
 			}
 
 			helper.AssertIssues(t, tc.Expected, runner.Issues)
+			want := map[string]string{}
+			if tc.Fixed != "" {
+				want["config.tf"] = tc.Fixed
+			}
+			helper.AssertChanges(t, want, runner.Changes())
 		})
 	}
 }

--- a/rules/terraform_required_providers_test.go
+++ b/rules/terraform_required_providers_test.go
@@ -11,8 +11,10 @@ func Test_TerraformRequiredProvidersRule(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Content  string
+		JSON     bool
 		Config   string
 		Expected helper.Issues
+		Fixed    string
 	}{
 		{
 			Name: "no version",
@@ -41,7 +43,7 @@ provider "template" {}
 			Name: "implicit provider - resource",
 			Content: `
 resource "random_string" "foo" {
-	length = 16
+  length = 16
 }
 `,
 			Expected: helper.Issues{
@@ -66,7 +68,7 @@ resource "random_string" "foo" {
 			Name: "implicit provider - data source",
 			Content: `
 data "template_file" "foo" {
-	template = ""
+  template = ""
 }
 `,
 			Expected: helper.Issues{
@@ -91,12 +93,12 @@ data "template_file" "foo" {
 			Name: "required_providers object",
 			Content: `
 terraform {
-	required_providers {
-		template = {
-			source  = "hashicorp/template"
-			version = "~> 2" 
-		}
-	}
+  required_providers {
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2" 
+    }
+  }
 }
 provider "template" {} 
 `,
@@ -106,9 +108,9 @@ provider "template" {}
 			Name: "legacy required_providers string",
 			Content: `
 terraform {
-	required_providers {
-		template = "~> 2"
-	}
+  required_providers {
+    template = "~> 2"
+  }
 }
 provider "template" {} 
 `,
@@ -120,25 +122,36 @@ provider "template" {}
 						Filename: "module.tf",
 						Start: hcl.Pos{
 							Line:   4,
-							Column: 14,
+							Column: 16,
 						},
 						End: hcl.Pos{
 							Line:   4,
-							Column: 20,
+							Column: 22,
 						},
 					},
 				},
 			},
+			Fixed: `
+terraform {
+  required_providers {
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2"
+    }
+  }
+}
+provider "template" {}
+`,
 		},
 		{
 			Name: "required_providers object missing version",
 			Content: `
 terraform {
-	required_providers {
-		template = {
-			source = "hashicorp/template"
-		}
-	}
+  required_providers {
+    template = {
+      source = "hashicorp/template"
+    }
+  }
 }
 
 provider "template" {} 
@@ -151,11 +164,11 @@ provider "template" {}
 						Filename: "module.tf",
 						Start: hcl.Pos{
 							Line:   4,
-							Column: 14,
+							Column: 16,
 						},
 						End: hcl.Pos{
 							Line:   6,
-							Column: 4,
+							Column: 6,
 						},
 					},
 				},
@@ -165,20 +178,20 @@ provider "template" {}
 			Name: "required_providers object missing version ignored",
 			Content: `
 terraform {
-	required_providers {
-		template = {
-			source = "hashicorp/template"
-		}
-	}
+  required_providers {
+    template = {
+      source = "hashicorp/template"
+    }
+  }
 }
 
 provider "template" {} 
 `,
 			Config: `
 rule "terraform_required_providers" {
-	enabled = true
+  enabled = true
 
-	version = false
+  version = false
 }
 `,
 			Expected: helper.Issues{},
@@ -187,11 +200,11 @@ rule "terraform_required_providers" {
 			Name: "required_providers object missing source",
 			Content: `
 terraform {
-	required_providers {
-		template = {
-			version = "~> 2"
-		}
-	}
+  required_providers {
+    template = {
+      version = "~> 2"
+    }
+  }
 }
 
 provider "template" {} 
@@ -204,34 +217,46 @@ provider "template" {}
 						Filename: "module.tf",
 						Start: hcl.Pos{
 							Line:   4,
-							Column: 14,
+							Column: 16,
 						},
 						End: hcl.Pos{
 							Line:   6,
-							Column: 4,
+							Column: 6,
 						},
 					},
 				},
 			},
+			Fixed: `
+terraform {
+  required_providers {
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2"
+    }
+  }
+}
+
+provider "template" {}
+`,
 		},
 		{
 			Name: "required_providers object missing source ignored",
 			Content: `
 terraform {
-	required_providers {
-		template = {
-			version = "~> 2"
-		}
-	}
+  required_providers {
+    template = {
+      version = "~> 2"
+    }
+  }
 }
 
 provider "template" {} 
 `,
 			Config: `
 rule "terraform_required_providers" {
-	enabled = true
+  enabled = true
 
-	source = false
+  source = false
 }
 `,
 			Expected: helper.Issues{},
@@ -240,9 +265,9 @@ rule "terraform_required_providers" {
 			Name: "required_providers empty object",
 			Content: `
 terraform {
-	required_providers {
-		template = {}
-	}
+  required_providers {
+    template = {}
+  }
 }
 
 provider "template" {} 
@@ -255,11 +280,11 @@ provider "template" {}
 						Filename: "module.tf",
 						Start: hcl.Pos{
 							Line:   4,
-							Column: 14,
+							Column: 16,
 						},
 						End: hcl.Pos{
 							Line:   4,
-							Column: 16,
+							Column: 18,
 						},
 					},
 				},
@@ -270,21 +295,32 @@ provider "template" {}
 						Filename: "module.tf",
 						Start: hcl.Pos{
 							Line:   4,
-							Column: 14,
+							Column: 16,
 						},
 						End: hcl.Pos{
 							Line:   4,
-							Column: 16,
+							Column: 18,
 						},
 					},
 				},
 			},
+			Fixed: `
+terraform {
+  required_providers {
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+}
+
+provider "template" {}
+`,
 		},
 		{
 			Name: "single provider with alias",
 			Content: `
 provider "template" {
-	alias = "b"
+  alias = "b"
 }
 `,
 			Expected: helper.Issues{
@@ -311,14 +347,14 @@ provider "template" {
 terraform {
   required_providers {
     template = {
-			source = "hashicorp/template"
-			version = "~> 2"
-		}
+      source = "hashicorp/template"
+      version = "~> 2"
+    }
   }
 }
 
 provider "template" {
-	version = "~> 2"
+  version = "~> 2"
 } 
 `,
 			Expected: helper.Issues{
@@ -345,15 +381,15 @@ provider "template" {
 terraform {
   required_providers {
     template = {
-			source = "hashicorp/template"
-			version = "~> 2"
-			configuration_aliases = [template.alias]
-		}
+      source = "hashicorp/template"
+      version = "~> 2"
+      configuration_aliases = [template.alias]
+    }
   }
 }
 
 data "template_file" "foo" {
-	provider = template.alias
+  provider = template.alias
 }
 `,
 			Expected: helper.Issues{},
@@ -364,15 +400,15 @@ data "template_file" "foo" {
 terraform {
   required_providers {
     template = {
-			source = "hashicorp/template"
-			version = "~> 2"
-		}
+      source = "hashicorp/template"
+      version = "~> 2"
+    }
   }
 }
 
 provider "template" {
-	alias   = "foo"
-	version = "~> 2"
+  alias   = "foo"
+  version = "~> 2"
 } 
 `,
 			Expected: helper.Issues{
@@ -404,11 +440,11 @@ data "terraform_remote_state" "foo" {}
 			Name: "builtin provider",
 			Content: `
 terraform {
-	required_providers {
-		test = {
-			source = "terraform.io/builtin/test"
-		}
-	}
+  required_providers {
+    test = {
+      source = "terraform.io/builtin/test"
+    }
+  }
 }
 resource "test_assertions" "foo" {}
 `,
@@ -478,14 +514,51 @@ resource "google_compute_instance" "foo" {
 				},
 			},
 		},
+		{
+			Name: "JSON syntax",
+			Content: `
+{
+  "terraform": {
+    "required_providers": {
+      "template": "~> 2"
+	}
+  },
+  "provider": {
+    "template": {}
+  }
+}`,
+			JSON: true,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: "Legacy version constraint for provider \"template\" in `required_providers`",
+					Range: hcl.Range{
+						Filename: "module.tf.json",
+						Start: hcl.Pos{
+							Line:   5,
+							Column: 19,
+						},
+						End: hcl.Pos{
+							Line:   5,
+							Column: 25,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	rule := NewTerraformRequiredProvidersRule()
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
+			filename := "module.tf"
+			if tc.JSON {
+				filename += ".json"
+			}
+
 			runner := testRunner(t, map[string]string{
-				"module.tf":   tc.Content,
+				filename:      tc.Content,
 				".tflint.hcl": tc.Config,
 			})
 
@@ -494,6 +567,11 @@ resource "google_compute_instance" "foo" {
 			}
 
 			helper.AssertIssues(t, tc.Expected, runner.Runner.(*helper.Runner).Issues)
+			want := map[string]string{}
+			if tc.Fixed != "" {
+				want[filename] = tc.Fixed
+			}
+			helper.AssertChanges(t, want, runner.Runner.(*helper.Runner).Changes())
 		})
 	}
 }

--- a/rules/terraform_unused_declarations.go
+++ b/rules/terraform_unused_declarations.go
@@ -74,28 +74,31 @@ func (r *TerraformUnusedDeclarationsRule) Check(rr tflint.Runner) error {
 	}
 
 	for _, variable := range decl.Variables {
-		if err := runner.EmitIssue(
+		if err := runner.EmitIssueWithFix(
 			r,
 			fmt.Sprintf(`variable "%s" is declared but not used`, variable.Labels[0]),
 			variable.DefRange,
+			func(f tflint.Fixer) error { return f.RemoveExtBlock(variable) },
 		); err != nil {
 			return err
 		}
 	}
 	for _, data := range decl.DataResources {
-		if err := runner.EmitIssue(
+		if err := runner.EmitIssueWithFix(
 			r,
 			fmt.Sprintf(`data "%s" "%s" is declared but not used`, data.Labels[0], data.Labels[1]),
 			data.DefRange,
+			func(f tflint.Fixer) error { return f.RemoveExtBlock(data) },
 		); err != nil {
 			return err
 		}
 	}
 	for _, local := range decl.Locals {
-		if err := runner.EmitIssue(
+		if err := runner.EmitIssueWithFix(
 			r,
 			fmt.Sprintf(`local.%s is declared but not used`, local.Name),
 			local.DefRange,
+			func(f tflint.Fixer) error { return f.RemoveAttribute(local.Attribute) },
 		); err != nil {
 			return err
 		}

--- a/terraform/ruleset.go
+++ b/terraform/ruleset.go
@@ -107,14 +107,7 @@ func (r *RuleSet) ApplyConfig(body *hclext.BodyContent) error {
 	return nil
 }
 
-// Check runs inspection for each rule by applying Runner.
-func (r *RuleSet) Check(rr tflint.Runner) error {
-	runner := NewRunner(rr)
-
-	for _, rule := range r.EnabledRules {
-		if err := rule.Check(runner); err != nil {
-			return fmt.Errorf("Failed to check `%s` rule: %s", rule.Name(), err)
-		}
-	}
-	return nil
+// NewRunner injects a custom runner
+func (r *RuleSet) NewRunner(runner tflint.Runner) (tflint.Runner, error) {
+	return NewRunner(runner), nil
 }

--- a/terraform/runner.go
+++ b/terraform/runner.go
@@ -93,8 +93,9 @@ func (r *Runner) GetLocals() (map[string]*Local, hcl.Diagnostics) {
 
 			for name, attr := range attrs {
 				locals[name] = &Local{
-					Name:     attr.Name,
-					DefRange: attr.Range,
+					Name:      attr.Name,
+					Attribute: attr,
+					DefRange:  attr.Range,
 				}
 			}
 		}

--- a/terraform/runner_test.go
+++ b/terraform/runner_test.go
@@ -165,6 +165,7 @@ locals {
 
 			opts := []cmp.Option{
 				cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+				cmpopts.IgnoreFields(Local{}, "Attribute"),
 			}
 			if diff := cmp.Diff(got, test.want, opts...); diff != "" {
 				t.Error(diff)

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -59,8 +59,9 @@ func decodeModuleCall(block *hclext.Block) (*ModuleCall, hcl.Diagnostics) {
 
 // Local represents a single entry from a "locals" block.
 type Local struct {
-	Name     string
-	DefRange hcl.Range
+	Name      string
+	Attribute *hcl.Attribute
+	DefRange  hcl.Range
 }
 
 // ProviderRef represents a reference to a provider like `provider = google.europe` in a resource or module.


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1755
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/254

This PR adds support for autofix in the following rules:

- `terraform_comment_syntax`
- `terraform_deprecated_index`
- `terraform_deprecated_interpolation`
- `terraform_empty_list_equality`
- `terraform_required_provider`
  - However, only issues with missing `source` can be fixed
- `terraform_unused_declarations`
  - HCL native syntax only

In TFLint v0.47, `tflint --fix` can automatically fix these issues.