### PR TITLE
Add example for terraform_deprecated_index fix

### DIFF
--- a/docs/rules/terraform_deprecated_index.md
+++ b/docs/rules/terraform_deprecated_index.md
@@ -53,3 +53,19 @@ Terraform v0.12 supports traditional square brackets for accessing list items by
 ## How To Fix
 
 Switch to the square bracket syntax when accessing items in list, including resources that use `count`.
+
+Example:
+
+```
+locals {
+  list  = [{a = "b}, {a = "c"}]
+  value = list.*.a
+}
+```
+Change this to: 
+```
+locals {
+  list  = [{a = "b}, {a = "c"}]
+  value = list[*].a
+}
+```


### PR DESCRIPTION
It took a while for me to figure out how to fix `terraform_deprecated_index` warnings. It would have helped me if there was an example.