### PR TITLE
terraform_naming_convention: Add support for checks and scoped data sources

### DIFF
--- a/docs/rules/terraform_naming_convention.md
+++ b/docs/rules/terraform_naming_convention.md
@@ -8,6 +8,7 @@ Enforces naming conventions for the following blocks:
 * Local values
 * Modules
 * Data sources
+* Checks
 
 ## Configuration
 
@@ -23,6 +24,7 @@ module | | Block settings to override naming convention for modules
 output | | Block settings to override naming convention for output values
 resource | | Block settings to override naming convention for resources
 variable | | Block settings to override naming convention for input variables
+check | | Block settings to override naming convention for checks
 
 
 #### `format`

--- a/rules/terraform_naming_convention.go
+++ b/rules/terraform_naming_convention.go
@@ -128,6 +128,19 @@ func (r *TerraformNamingConventionRule) Check(rr tflint.Runner) error {
 				LabelNames: []string{"name"},
 				Body:       &hclext.BodySchema{},
 			},
+			{
+				Type:       "check",
+				LabelNames: []string{"name"},
+				Body: &hclext.BodySchema{
+					Blocks: []hclext.BlockSchema{
+						{
+							Type:       "data",
+							LabelNames: []string{"type", "name"},
+							Body:       &hclext.BodySchema{},
+						},
+					},
+				},
+			},
 		},
 	}, &tflint.GetModuleContentOption{ExpandMode: tflint.ExpandModeNone})
 	if err != nil {
@@ -144,6 +157,14 @@ func (r *TerraformNamingConventionRule) Check(rr tflint.Runner) error {
 	for _, block := range blocks[dataBlockName] {
 		if err := nameValidator.checkBlock(runner, r, dataBlockName, block.Labels[1], &block.DefRange); err != nil {
 			return err
+		}
+	}
+	checkBlockName := "check"
+	for _, checkBlock := range blocks[checkBlockName] {
+		for _, block := range checkBlock.Body.Blocks {
+			if err := nameValidator.checkBlock(runner, r, dataBlockName, block.Labels[1], &block.DefRange); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/rules/terraform_naming_convention.go
+++ b/rules/terraform_naming_convention.go
@@ -29,6 +29,7 @@ type terraformNamingConventionRuleConfig struct {
 	Output   *BlockFormatConfig `hclext:"output,block"`
 	Resource *BlockFormatConfig `hclext:"resource,block"`
 	Variable *BlockFormatConfig `hclext:"variable,block"`
+	Check    *BlockFormatConfig `hclext:"check,block"`
 }
 
 // CustomFormatConfig defines a custom format that can be used instead of the predefined formats
@@ -212,6 +213,17 @@ func (r *TerraformNamingConventionRule) Check(rr tflint.Runner) error {
 	}
 	for _, block := range blocks[variableBlockName] {
 		if err := nameValidator.checkBlock(runner, r, variableBlockName, block.Labels[0], &block.DefRange); err != nil {
+			return err
+		}
+	}
+
+	// checks
+	nameValidator, err = config.Check.getNameValidator(defaultNameValidator, &config, checkBlockName)
+	if err != nil {
+		return err
+	}
+	for _, block := range blocks[checkBlockName] {
+		if err := nameValidator.checkBlock(runner, r, checkBlockName, block.Labels[0], &block.DefRange); err != nil {
 			return err
 		}
 	}

--- a/rules/terraform_naming_convention_test.go
+++ b/rules/terraform_naming_convention_test.go
@@ -299,6 +299,36 @@ data "aws_eip" "foo" {
 			Config:   config,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: fmt.Sprintf("data: %s - Invalid snake_case in a check block", testType),
+			Content: `
+check "ip_check" {
+  data "aws_eip" "dash-name" {
+  }
+}`,
+			Config: config,
+			Expected: helper.Issues{
+				{
+					Rule:    rule,
+					Message: fmt.Sprintf("data name `dash-name` must match the following %s", formatName),
+					Range: hcl.Range{
+						Filename: "tests.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3},
+						End:      hcl.Pos{Line: 3, Column: 29},
+					},
+				},
+			},
+		},
+		{
+			Name: fmt.Sprintf("data: %s - Valid snake_case in a check block", testType),
+			Content: `
+check "ip_check" {
+  data "aws_eip" "foo_bar" {
+  }
+}`,
+			Config:   config,
+			Expected: helper.Issues{},
+		},
 	}
 
 	for _, tc := range cases {

--- a/rules/terraform_naming_convention_test.go
+++ b/rules/terraform_naming_convention_test.go
@@ -302,7 +302,7 @@ data "aws_eip" "foo" {
 		{
 			Name: fmt.Sprintf("data: %s - Invalid snake_case in a check block", testType),
 			Content: `
-check "ip_check" {
+check "ignored" {
   data "aws_eip" "dash-name" {
   }
 }`,
@@ -322,7 +322,7 @@ check "ip_check" {
 		{
 			Name: fmt.Sprintf("data: %s - Valid snake_case in a check block", testType),
 			Content: `
-check "ip_check" {
+check "ignored" {
   data "aws_eip" "foo_bar" {
   }
 }`,
@@ -2953,6 +2953,62 @@ variable "camelCase" {
 			}
 
 			helper.AssertIssues(t, tc.Expected, runner.Runner.(*helper.Runner).Issues)
+		})
+	}
+}
+
+func Test_TerraformNamingConventionRule_Check(t *testing.T) {
+	rule := NewTerraformNamingConventionRule()
+
+	config := `
+rule "terraform_naming_convention" {
+  enabled = true
+
+  check {
+    format = "snake_case"
+  }
+}`
+
+	tests := []struct {
+		name    string
+		content string
+		want    helper.Issues
+	}{
+		{
+			name: "Invalid snake_case",
+			content: `
+check "dash-name" {
+}`,
+			want: helper.Issues{
+				{
+					Rule:    rule,
+					Message: "check name `dash-name` must match the following format: snake_case",
+					Range: hcl.Range{
+						Filename: "tests.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 18},
+					},
+				},
+			},
+		},
+		{
+			name: "Valid snake_case",
+			content: `
+check "foo_bar" {
+}`,
+			want: helper.Issues{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runner := testRunner(t, map[string]string{"tests.tf": test.content, ".tflint.hcl": config})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssues(t, test.want, runner.Runner.(*helper.Runner).Issues)
 		})
 	}
 }


### PR DESCRIPTION
See also https://developer.hashicorp.com/terraform/language/checks

Terraform v1.5 now supports check blocks and scoped (nested) data sources.
This PR adds support for them to the `terraform_naming_convention` rule.