### PR TITLE
terraform_unused_declarations: Make unused variable checks aware of validation blocks

### DIFF
--- a/rules/terraform_unused_declarations_test.go
+++ b/rules/terraform_unused_declarations_test.go
@@ -180,6 +180,30 @@ output "d" {
 			Expected: helper.Issues{},
 		},
 		{
+			Name: "variable used in validation block",
+			Content: `
+variable "unused" {
+  validation {
+    condition     = var.unused != ""
+    error_message = "variable should be empty string. got: ${var.unused}"
+  }
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformUnusedDeclarationsRule(),
+					Message: `variable "unused" is declared but not used`,
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 18},
+					},
+				},
+			},
+			Fixed: `
+`,
+		},
+		{
 			Name: "json",
 			JSON: true,
 			Content: `


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-terraform/issues/94

The `terraform_unused_declarations` rule recognizes unused variables by walking through all expressions and seeing if a variable reference exists. However, this way cannot recognize which block is being walked, so false negatives like https://github.com/terraform-linters/tflint-ruleset-terraform/issues/94 may occur.

This PR changes the rule so that if an expression reference is inside a variable validation block, it will not be marked as used.