### PR TITLE
terraform_unused_declarations: Add support for scoped data sources

### DIFF
--- a/rules/terraform_unused_declarations_test.go
+++ b/rules/terraform_unused_declarations_test.go
@@ -204,6 +204,29 @@ variable "unused" {
 `,
 		},
 		{
+			Name: "unused scoped data source",
+			Content: `
+check "unused" {
+  data "null_data_source" "unused" {}
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformUnusedDeclarationsRule(),
+					Message: `data "null_data_source" "unused" is declared but not used`,
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3},
+						End:      hcl.Pos{Line: 3, Column: 35},
+					},
+				},
+			},
+			Fixed: `
+check "unused" {
+}
+`,
+		},
+		{
 			Name: "json",
 			JSON: true,
 			Content: `


### PR DESCRIPTION
See also https://developer.hashicorp.com/terraform/language/checks

Terraform v1.5 now supports check blocks and scoped (nested) data sources.
This PR adds support for them to the `terraform_unused_declarations` rule.