### PR TITLE
workspace_remote: Suppress issues in Terraform v1.1+

### DIFF
--- a/docs/rules/terraform_workspace_remote.md
+++ b/docs/rules/terraform_workspace_remote.md
@@ -1,6 +1,6 @@
 # terraform_workspace_remote
 
-`terraform.workspace` should not be used with a "remote" backend with remote execution. 
+`terraform.workspace` should not be used with a "remote" backend with remote execution in Terraform v1.0.x.
 
 If remote operations are [disabled](https://www.terraform.io/docs/cloud/run/index.html#disabling-remote-operations) for your workspace, you can safely disable this rule:
 
@@ -10,12 +10,15 @@ rule "terraform_workspace_remote" {
 }
 ```
 
+This rule looks at `required_version` for Terraform version estimation. If the `required_version` is not declared, it is assumed that you are using a more recent version.
+
 > This rule is enabled by "recommended" preset.
 
 ## Example
 
 ```hcl
 terraform {
+  required_version = ">= 1.0"
   backend "remote" {
     # ...
   }
@@ -35,24 +38,24 @@ $ tflint
 Warning: terraform.workspace should not be used with a 'remote' backend (terraform_workspace_remote)
 
   on example.tf line 8:
-   8:   tags = {
-   9:     workspace = terraform.workspace
-  10:   }
+   9:   tags = {
+  10:     workspace = terraform.workspace
+  11:   }
 
-Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_workspace_remote.md
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_workspace_remote.md
 ```
 
 ## Why
 
-Terraform configuration may include the name of the [current workspace](https://www.terraform.io/docs/state/workspaces.html#current-workspace-interpolation) using the `${terraform.workspace}` interpolation sequence. However, when Terraform Cloud workspaces are executing Terraform runs remotely, the Terraform CLI always uses the `default` workspace.
+Terraform configuration may include the name of the [current workspace](https://developer.hashicorp.com/terraform/language/state/workspaces#current-workspace-interpolation) using the `${terraform.workspace}` interpolation sequence. However, when Terraform Cloud workspaces are executing Terraform runs remotely, the Terraform v1.0.x always uses the `default` workspace.
 
-The [remote](https://www.terraform.io/docs/backends/types/remote.html) backend is used with Terraform Cloud workspaces. Even if you set a `prefix` in the `workspaces` block, this value will be ignored during remote runs.
+The [remote](https://developer.hashicorp.com/terraform/language/settings/backends/remote) backend is used with Terraform Cloud workspaces. Even if you set a `prefix` in the `workspaces` block, this value will be ignored during remote runs.
 
-For more information, see the [`remote` backend workspaces documentation](https://www.terraform.io/docs/backends/types/remote.html#workspaces).
+For more information, see the [`remote` backend workspaces documentation](https://developer.hashicorp.com/terraform/language/settings/backends/remote#workspace-names).
 
 ## How To Fix
 
-Consider adding a variable to your configuration and setting it in each cloud workspace:
+If you still need support for Terarform v1.0.x, consider adding a variable to your configuration and setting it in each cloud workspace:
 
 ```tf
 variable "workspace" {
@@ -62,3 +65,5 @@ variable "workspace" {
 ```
 
 You can also name the variable based on what the workspace suffix represents in your configuration (e.g. environment).
+
+If you don't need support for Terraform v1.0.x, you can suppress the issue by updating the `required_version` to not contain 1.0.x.


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-terraform/issues/154

The `terraform_workspace_remote` rule always emits issues when using `${terraform.workspace}` with a remote backend. This was introduced to avoid the unintuitive behavior of values always being "default", but this behavior has been improved in 1.1.0.
https://github.com/terraform-linters/tflint/pull/738

This PR changes it to take into account the Terraform version when emitting issues. Use `required_version` to guess the version. If not declared, it is implicitly assumed to be 1.1+.