### PR TITLE
Allow no outputs.tf in standard module rule

### DIFF
--- a/docs/rules/terraform_standard_module_structure.md
+++ b/docs/rules/terraform_standard_module_structure.md
@@ -2,6 +2,17 @@
 
 Ensure that a module complies with the Terraform [Standard Module Structure](https://www.terraform.io/docs/modules/index.html#standard-module-structure)
 
+## Configuration
+
+```hcl
+rule "terraform_standard_module_structure" {
+  enabled = true
+
+  # defaults
+  outputs = true
+}
+```
+
 ## Example
 
 _main.tf_
@@ -29,3 +40,5 @@ Terraform's documentation outlines a [Standard Module Structure](https://www.ter
 
 * Move blocks to their conventional files as needed
 * Create empty files even if no `variable` or `output` blocks are defined
+
+Optionally, you can disable enforcement of an `outputs.tf` file by setting the `outputs` rule to `false`.

--- a/rules/terraform_standard_module_structure_test.go
+++ b/rules/terraform_standard_module_structure_test.go
@@ -12,6 +12,7 @@ func Test_TerraformStandardModuleStructureRule(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Content  map[string]string
+		Config   string
 		Expected helper.Issues
 	}{
 		{
@@ -56,7 +57,7 @@ func Test_TerraformStandardModuleStructureRule(t *testing.T) {
 			Content: map[string]string{
 				"foo/main.tf": "",
 				"foo/variables.tf": `
-variable "v" {}				
+variable "v" {}
 				`,
 			},
 			Expected: helper.Issues{
@@ -69,6 +70,23 @@ variable "v" {}
 					},
 				},
 			},
+		},
+		{
+			Name: "allow no outputs.tf",
+			Content: map[string]string{
+				"foo/main.tf": "",
+				"foo/variables.tf": `
+variable "v" {}
+				`,
+				".tflint.hcl": `
+rule "terraform_standard_module_structure" {
+  enabled = true
+
+  outputs = false
+}
+`,
+			},
+			Expected: helper.Issues{},
 		},
 		{
 			Name: "move variable",


### PR DESCRIPTION
We find having an empty outputs.tf adds cruft to our modules, so we'd like to be able to turn it off.