### PR TITLE
Add range to terraform_required_version errors

### DIFF
--- a/rules/terraform_required_version_test.go
+++ b/rules/terraform_required_version_test.go
@@ -1,8 +1,10 @@
 package rules
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
 
@@ -25,6 +27,17 @@ terraform {}
 				{
 					Rule:    NewTerraformRequiredVersionRule(),
 					Message: "terraform \"required_version\" attribute is required",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 10,
+						},
+					},
 				},
 			},
 		},
@@ -53,6 +66,31 @@ terraform {
 `,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "no terraform block",
+			Content: `
+locals {
+	foo = "bar"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredVersionRule(),
+					Message: "terraform \"required_version\" attribute is required",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 1,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	rule := NewTerraformRequiredVersionRule()
@@ -65,6 +103,87 @@ terraform {
 			}
 			runner := helper.TestRunner(t, files)
 
+			if err := rule.Check(runner); err != nil {
+				t.Fatal(err)
+			}
+
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}
+
+func Test_TerraformRequiredVersionRuleMultipleFiles(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Files    []string
+		Expected helper.Issues
+	}{
+		{
+			Name:  "has terraform.tf and main.tf",
+			Files: []string{"modules/foo/main.tf", "modules/foo/terraform.tf"},
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredVersionRule(),
+					Message: "terraform \"required_version\" attribute is required",
+					Range: hcl.Range{
+						Filename: filepath.FromSlash("modules/foo/terraform.tf"),
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 1,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "has main.tf",
+			Files: []string{"modules/foo/outputs.tf", "modules/foo/main.tf", "modules/foo/variables.tf"},
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredVersionRule(),
+					Message: "terraform \"required_version\" attribute is required",
+					Range: hcl.Range{
+						Filename: filepath.FromSlash("modules/foo/main.tf"),
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 1,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "has neither terraform.tf or main.tf",
+			Files: []string{"modules/foo/variables.tf", "modules/foo/outputs.tf"},
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredVersionRule(),
+					Message: "terraform \"required_version\" attribute is required",
+					Range: hcl.Range{
+						Filename: filepath.FromSlash("modules/foo/terraform.tf"),
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewTerraformRequiredVersionRule()
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var files = map[string]string{}
+			for _, filename := range tc.Files {
+				files[filepath.FromSlash(filename)] = ""
+			}
+			runner := helper.TestRunner(t, files)
 			if err := rule.Check(runner); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Fixes #177 

I wondered about sorting the blocks / filenames or looking for `main.tf`, but decided to keep it simple.

A couple questions came up for me:

- Is it ok to use the first block? Should we sort by filename or line number or something?

- Pulling an arbitrary filename from the map of files doesn't feel great. It seems weird for the error to suggest placing the `required_version` in `variables.tf` for instance. Maybe we should just show the directory if no `"terraform"` blocks are found? We could parse that out of the filename.

Let me know what you think.

Thanks!