### PR TITLE
gofmt rules/terraform_deprecated_lookup.go

### DIFF
--- a/rules/terraform_deprecated_lookup.go
+++ b/rules/terraform_deprecated_lookup.go
@@ -77,5 +77,3 @@ func (r *TerraformDeprecatedLookupRule) Check(runner tflint.Runner) error {
 
 	return nil
 }
-
-


### PR DESCRIPTION
Noticed from running `go fmt ./...` that this file was not formatted correctly.