### PR TITLE
deprecated_interpolation: Prevent autofix from producing ambiguous attribute keys

### DIFF
--- a/rules/terraform_deprecated_interpolation_test.go
+++ b/rules/terraform_deprecated_interpolation_test.go
@@ -175,6 +175,58 @@ resource "null_resource" "a" {
   triggers = var.triggers
 }`,
 		},
+		{
+			Name: "interpolation as an object key",
+			Content: `
+resource "null_resource" "a" {
+  triggers = {
+    "${var.triggers}" = "foo"
+  }
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 4, Column: 5},
+						End:      hcl.Pos{Line: 4, Column: 22},
+					},
+				},
+			},
+			Fixed: `
+resource "null_resource" "a" {
+  triggers = {
+    (var.triggers) = "foo"
+  }
+}`,
+		},
+		{
+			Name: "interpolation in an object key",
+			Content: `
+resource "null_resource" "a" {
+  triggers = {
+    upper("${var.triggers}") = "foo"
+  }
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 4, Column: 11},
+						End:      hcl.Pos{Line: 4, Column: 28},
+					},
+				},
+			},
+			Fixed: `
+resource "null_resource" "a" {
+  triggers = {
+    upper(var.triggers) = "foo"
+  }
+}`,
+		},
 	}
 
 	rule := NewTerraformDeprecatedInterpolationRule()


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-terraform/issues/185

The current autofix for the `terraform_deprecated_interpolation` rule does not recognize expression context and will always fix `"${var.foo}"` to `var.foo`. However, if an object key is a deprecated interpolation, it must be wrapped in parentheses to prevent ambiguous attribute key errors.

This PR takes inspiration from https://github.com/hashicorp/terraform/pull/26949 and fixes it so that autofixed code are wrapped in parentheses when the object key is a deprecated interpolation.

**Before**

```hcl
locals {
  tags = {
    var.foo = "bar" # => ambiguous attribute key
  }
}
```

**After**

```hcl
locals {
  tags = {
    (var.foo) = "bar"
  }
}
```