### PR TITLE
terraform_map_duplicate_keys: Temporarily ignore key evaluation errors

### DIFF
--- a/rules/terraform_map_duplicate_keys.go
+++ b/rules/terraform_map_duplicate_keys.go
@@ -80,11 +80,10 @@ func (r *TerraformMapDuplicateKeysRule) checkObjectConsExpr(e hcl.Expression, ru
 		} else {
 			err := runner.EvaluateExpr(expr, &val, nil)
 			if err != nil {
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "failed to evaluate expression",
-					Detail:   err.Error(),
-				})
+				// When a key fails to evaluate, ignore the key and continue processing rather than terminating with an error.
+				// This is due to a limitation that expressions with different scopes, such as for expressions, cannot be evaluated.
+				// @see https://github.com/terraform-linters/tflint-ruleset-terraform/issues/199
+				logger.Debug("Failed to evaluate key. The key will be ignored", "range", expr.Range(), "error", err.Error())
 				continue
 			}
 		}

--- a/rules/terraform_map_duplicate_keys_test.go
+++ b/rules/terraform_map_duplicate_keys_test.go
@@ -193,6 +193,18 @@ resource "null_resource" "test" {
 				},
 			},
 		},
+		{
+			Name: "keys in for expressions",
+			Content: `
+resource "null_resource" "test" {
+  list = [for a in ["foo", "bar"] : {
+    "${a}_baz" = 1
+	"foo_baz" = 2
+  }]
+}`,
+			// The current implementation cannot find duplicate keys in for expressions.
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewTerraformMapDuplicateKeysRule()


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-terraform/issues/199

The `terraform_map_duplicate_keys` rule, added in v0.9.0, walks through all expressions and evaluates their values ​​to see if a map has duplicate keys.

In most cases, this approach works well because the evaluation scope is the same across the board, but expressions with different scopes, such as [for expressions](https://developer.hashicorp.com/terraform/language/expressions/for), cannot be evaluated correctly without first expanding the for expressions.

This issue should be resolved at the SDK level, but since it is currently it is not, we will mitigate this issue by temporarily ignoring key evaluation errors. Note that this may result in duplicate keys not being detected correctly when using for expressions.