### PR TITLE
Support provider-defined functions

### DIFF
--- a/rules/terraform_required_providers_test.go
+++ b/rules/terraform_required_providers_test.go
@@ -546,6 +546,30 @@ resource "google_compute_instance" "foo" {
 				},
 			},
 		},
+		{
+			Name: "provider-defined function",
+			Content: `
+output "foo" {
+	value = provider::time::rfc3339_parse("2023-07-25T23:43:16Z")
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: "Missing version constraint for provider \"time\" in `required_providers`",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   3,
+							Column: 10,
+						},
+						End: hcl.Pos{
+							Line:   3,
+							Column: 63,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	rule := NewTerraformRequiredProvidersRule()

--- a/rules/terraform_unused_required_providers_test.go
+++ b/rules/terraform_unused_required_providers_test.go
@@ -244,6 +244,22 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 			`,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "used - provider-defined function",
+			Content: `
+				terraform {
+					required_providers {
+						time = {
+							source = "hashicorp/time"
+						}
+					}
+				}
+				output "foo" {
+					value = provider::time::rfc3339_parse("2023-07-25T23:43:16Z")
+				}
+			`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewTerraformUnusedRequiredProvidersRule()

--- a/terraform/runner_test.go
+++ b/terraform/runner_test.go
@@ -260,6 +260,16 @@ check "my_check" {
 				"aws": {Name: "aws", DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3, Column: 3}, End: hcl.Pos{Line: 3, Column: 24}}},
 			},
 		},
+		{
+			name: "provider-defined function",
+			content: `
+output "foo" {
+  value = provider::time::rfc3339_parse("2023-07-25T23:43:16Z")
+}`,
+			want: map[string]*ProviderRef{
+				"time": {Name: "time", DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3, Column: 11}, End: hcl.Pos{Line: 3, Column: 64}}},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #213

This PR addresses an issue with the `terraform_unused_required_providers` rule, which does not currently support provider-defined functions introduced in Terraform 1.8. As a result, valid configurations using these functions were incorrectly flagged as unused providers.

Changes:
- Updated the `GetProviderRefs` function to correctly recognize provider references in provider-defined functions by walking through expressions and identifying function calls with the `provider::` prefix.
- Added logic to extract provider names from these function calls and include them in the set of used providers, preventing false positives in the `terraform_unused_required_providers` rule.
- Additionally, since `GetProviderRefs` is also utilized by the `terraform_required_providers` rule, this update enables the correct detection of provider-defined functions in this rule as well.