### PR TITLE
Fix issues caused by multiple terraform blocks

### DIFF
--- a/rules/terraform_required_providers.go
+++ b/rules/terraform_required_providers.go
@@ -151,7 +151,9 @@ func (r *TerraformRequiredProvidersRule) Check(rr tflint.Runner) error {
 	requiredProviders := hclext.Attributes{}
 	for _, terraform := range body.Blocks {
 		for _, requiredProvidersBlock := range terraform.Body.Blocks {
-			requiredProviders = requiredProvidersBlock.Body.Attributes
+			for name, attr := range requiredProvidersBlock.Body.Attributes {
+				requiredProviders[name] = attr
+			}
 		}
 	}
 

--- a/rules/terraform_unused_required_providers.go
+++ b/rules/terraform_unused_required_providers.go
@@ -82,8 +82,10 @@ func (r *TerraformUnusedRequiredProvidersRule) Check(rr tflint.Runner) error {
 			}
 
 			for _, block := range content.Blocks {
-				var attrDiags hcl.Diagnostics
-				requiredProviders, attrDiags = block.Body.JustAttributes()
+				attributes, attrDiags := block.Body.JustAttributes()
+				for k, v := range attributes {
+					requiredProviders[k] = v
+				}
 				diags = diags.Extend(attrDiags)
 				if diags.HasErrors() {
 					continue

--- a/rules/terraform_unused_required_providers_test.go
+++ b/rules/terraform_unused_required_providers_test.go
@@ -260,6 +260,43 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 			`,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "unused - in multiple terraform blocks",
+			Content: `
+				terraform {
+					required_providers {
+						aws = {
+							source = "hashicorp/aws"
+						}
+					}
+				}
+				terraform {
+					required_providers {
+						null = {
+							source = "hashicorp/null"
+						}
+					}
+				}
+				resource "null_resource" "foo" {}
+			`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformUnusedRequiredProvidersRule(),
+					Message: "provider 'aws' is declared in required_providers but not used by the module",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 7,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 8,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	rule := NewTerraformUnusedRequiredProvidersRule()

--- a/rules/terraform_workspace_remote_test.go
+++ b/rules/terraform_workspace_remote_test.go
@@ -299,6 +299,23 @@ resource "kubernetes_secret" "my_secret" {
 }`,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "required_version does not support 1.0.x by multiple setting",
+			Content: `
+terraform {
+	required_version = "< 1.9"
+	backend "remote" {}
+}
+terraform {
+	required_version = ">= 1.1"
+}
+resource "null_resource" "a" {
+	triggers = {
+		w = terraform.workspace
+	}
+}`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewTerraformWorkspaceRemoteRule()


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-terraform/issues/205

Some rules that reference terraform blocks do not assume that blocks can be defined multiple times and can lead to inconsistent results in that case.