### PR TITLE
Add new rules for attribute notation and dynamic access

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -12,6 +12,7 @@ All rules are enabled by default, but by setting `preset = "recommended"`, you c
 |[terraform_deprecated_lookup](terraform_deprecated_lookup.md)|Disallow deprecated `lookup()` function with only 2 arguments.|✔|
 |[terraform_documented_outputs](terraform_documented_outputs.md)|Disallow `output` declarations without description||
 |[terraform_documented_variables](terraform_documented_variables.md)|Disallow `variable` declarations without description||
+|[terraform_dynamic_attribute_notation](terraform_dynamic_attribute_notation.md)|Enforce bracket notation for dynamic attribute access|✔|
 |[terraform_empty_list_equality](terraform_empty_list_equality.md)|Disallow comparisons with `[]` when checking if a collection is empty|✔|
 |[terraform_map_duplicate_keys](terraform_map_duplicate_keys.md)|Disallow duplicate keys in a map object|✔|
 |[terraform_module_pinned_source](terraform_module_pinned_source.md)|Disallow specifying a git or mercurial repository as a module source without pinning to a version|✔|
@@ -20,6 +21,7 @@ All rules are enabled by default, but by setting `preset = "recommended"`, you c
 |[terraform_required_providers](terraform_required_providers.md)|Require that all providers have version constraints through required_providers|✔|
 |[terraform_required_version](terraform_required_version.md)|Disallow `terraform` declarations without require_version|✔|
 |[terraform_standard_module_structure](terraform_standard_module_structure.md)|Ensure that a module complies with the Terraform Standard Module Structure||
+|[terraform_static_attribute_notation](terraform_static_attribute_notation.md)|Enforce dot notation for static attribute access|✔|
 |[terraform_typed_variables](terraform_typed_variables.md)|Disallow `variable` declarations without type|✔|
 |[terraform_unused_declarations](terraform_unused_declarations.md)|Disallow variables, data sources, and locals that are declared but never used|✔|
 |[terraform_unused_required_providers](terraform_unused_required_providers.md)|Check that all `required_providers` are used in the module||

--- a/docs/rules/terraform_dynamic_attribute_notation.md
+++ b/docs/rules/terraform_dynamic_attribute_notation.md
@@ -1,0 +1,41 @@
+# terraform_dynamic_attribute_notation
+
+Enforce bracket notation for dynamic attribute access in Terraform configurations.
+
+> This rule is enabled by "recommended" preset.
+
+## Example
+
+```hcl
+resource "aws_instance" "web" {
+  for_each = local.instances
+  subnet_id = each.value.subnet_id  # dot notation in dynamic context
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: Must use bracket notation [] for dynamic attributes. Use each.value["subnet_id"] instead (terraform_dynamic_attribute_notation)
+
+  on main.tf line 3:
+   3:   subnet_id = each.value.subnet_id
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.9.0/docs/rules/terraform_dynamic_attribute_notation.md
+```
+
+## Why
+
+In dynamic contexts (e.g., inside a `for_each` block, `for` expression, or when using `count`), using dot notation may lead to ambiguous results. Using bracket notation makes the attribute access explicit and prevents potential confusion.
+
+## How To Fix
+
+Replace dot notation with bracket notation in dynamic contexts:
+
+```hcl
+resource "aws_instance" "web" {
+  for_each = local.instances
+  subnet_id = each.value["subnet_id"]
+}
+``` 

--- a/docs/rules/terraform_static_attribute_notation.md
+++ b/docs/rules/terraform_static_attribute_notation.md
@@ -1,0 +1,39 @@
+# terraform_static_attribute_notation
+
+Enforce dot notation for static attribute access in Terraform configurations.
+
+> This rule is enabled by "recommended" preset.
+
+## Example
+
+```hcl
+resource "aws_instance" "web" {
+  instance_type = var.instance["type"]  # bracket notation in static context
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: Must use dot notation for static attributes (terraform_static_attribute_notation)
+
+  on main.tf line 2:
+   2:   instance_type = var.instance["type"]
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.9.0/docs/rules/terraform_static_attribute_notation.md
+```
+
+## Why
+
+In static contexts (when accessing literal attribute keys), using bracket notation is unnecessary and reduces readability. Using dot notation makes the code cleaner and easier to understand.
+
+## How To Fix
+
+Replace bracket notation with dot notation in static contexts:
+
+```hcl
+resource "aws_instance" "web" {
+  instance_type = var.instance.type
+}
+``` 

--- a/rules/terraform_dynamic_attribute_notation.go
+++ b/rules/terraform_dynamic_attribute_notation.go
@@ -1,0 +1,194 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-terraform/project"
+)
+
+// TerraformDynamicAttributeNotationRule checks if bracket notation is used in dynamic contexts
+type TerraformDynamicAttributeNotationRule struct {
+	tflint.DefaultRule
+}
+
+// NewTerraformDynamicAttributeNotationRule returns a new rule
+func NewTerraformDynamicAttributeNotationRule() *TerraformDynamicAttributeNotationRule {
+	return &TerraformDynamicAttributeNotationRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformDynamicAttributeNotationRule) Name() string {
+	return "terraform_dynamic_attribute_notation"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformDynamicAttributeNotationRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *TerraformDynamicAttributeNotationRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *TerraformDynamicAttributeNotationRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check walks all expressions and emit issues if dot notation is found in dynamic contexts
+func (r *TerraformDynamicAttributeNotationRule) Check(runner tflint.Runner) error {
+	path, err := runner.GetModulePath()
+	if err != nil {
+		return err
+	}
+	if !path.IsRoot() {
+		// This rule does not evaluate child modules
+		return nil
+	}
+
+	diags := runner.WalkExpressions(tflint.ExprWalkFunc(func(expr hcl.Expression) hcl.Diagnostics {
+		if !isDynamicContext(expr) {
+			return nil
+		}
+
+		if attr, ok := expr.(*hclsyntax.ScopeTraversalExpr); ok {
+			// Skip if this is not a traversal with at least one attribute
+			if len(attr.Traversal) < 2 {
+				return nil
+			}
+
+			// Skip if already using valid bracket notation for dynamic attributes in 'each' context
+			if len(attr.Traversal) >= 2 {
+				if root, ok := attr.Traversal[0].(hcl.TraverseRoot); ok && root.Name == "each" {
+					if token, ok := attr.Traversal[1].(hcl.TraverseAttr); ok && token.Name == "value" {
+						valid := true
+						for i := 2; i < len(attr.Traversal); i++ {
+							if _, ok := attr.Traversal[i].(hcl.TraverseIndex); !ok {
+								valid = false
+								break
+							}
+						}
+						if valid {
+							return nil
+						}
+					}
+				}
+			}
+
+			// Find the first dot notation attribute
+			hasDotNotation := false
+			for i := 1; i < len(attr.Traversal); i++ {
+				if _, ok := attr.Traversal[i].(hcl.TraverseAttr); ok {
+					// Skip if this is preceded by an index traversal
+					if i > 1 {
+						if _, ok := attr.Traversal[i-1].(hcl.TraverseIndex); ok {
+							continue
+						}
+					}
+					hasDotNotation = true
+					break
+				}
+			}
+
+			if !hasDotNotation {
+				return nil
+			}
+
+			// Build the fixed expression
+			result := ""
+			if len(attr.Traversal) > 0 {
+				if root, ok := attr.Traversal[0].(hcl.TraverseRoot); ok && root.Name == "each" {
+					result = "each.value"
+					for i := 1; i < len(attr.Traversal); i++ {
+						if i == 1 {
+							if attr, ok := attr.Traversal[i].(hcl.TraverseAttr); ok && attr.Name == "value" {
+								continue
+							}
+						}
+						switch token := attr.Traversal[i].(type) {
+						case hcl.TraverseAttr:
+							result += fmt.Sprintf("[\"%s\"]", token.Name)
+						case hcl.TraverseIndex:
+							result += fmt.Sprintf("[%s]", token.Key.AsString())
+						}
+					}
+				} else {
+					var useDot = true
+					switch token := attr.Traversal[0].(type) {
+					case hcl.TraverseRoot:
+						result = token.Name
+					case hcl.TraverseAttr:
+						result = token.Name
+					}
+					for i := 1; i < len(attr.Traversal); i++ {
+						switch token := attr.Traversal[i].(type) {
+						case hcl.TraverseAttr:
+							if useDot {
+								result += "." + token.Name
+							} else {
+								result += fmt.Sprintf("[%c%s%c]", '"', token.Name, '"')
+							}
+						case hcl.TraverseIndex:
+							useDot = false
+							result += fmt.Sprintf("[%s]", token.Key.AsString())
+						}
+					}
+				}
+			}
+
+			fmt.Printf("Transforming traversal: %#v\n", attr.Traversal)
+			fmt.Printf("Initial result: %s\n", result)
+			for i, token := range attr.Traversal {
+				fmt.Printf("Token %d: %T = %+v\n", i, token, token)
+			}
+
+			if err := runner.EmitIssueWithFix(
+				r,
+				"Must use bracket notation [] for dynamic attributes",
+				attr.Range(),
+				func(f tflint.Fixer) error {
+					return f.ReplaceText(attr.Range(), result)
+				},
+			); err != nil {
+				return hcl.Diagnostics{
+					{
+						Severity: hcl.DiagError,
+						Summary:  "Failed to emit issue",
+						Detail:   err.Error(),
+					},
+				}
+			}
+		}
+		return nil
+	}))
+
+	if diags.HasErrors() {
+		return diags
+	}
+	return nil
+}
+
+func isDynamicContext(expr hcl.Expression) bool {
+	// Check if we're inside a dynamic context
+	vars := expr.Variables()
+	for _, v := range vars {
+		if len(v) > 0 {
+			root, ok := v[0].(hcl.TraverseRoot)
+			if ok && (root.Name == "each" || root.Name == "count") {
+				return true
+			}
+		}
+	}
+
+	// Check parent context
+	switch expr.(type) {
+	case *hclsyntax.ForExpr, *hclsyntax.SplatExpr:
+		return true
+	}
+
+	return false
+}

--- a/rules/terraform_dynamic_attribute_notation_test.go
+++ b/rules/terraform_dynamic_attribute_notation_test.go
@@ -1,0 +1,116 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_TerraformDynamicAttributeNotationRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+		Fixed    string
+	}{
+		{
+			Name: "dot notation in for_each",
+			Content: `
+resource "aws_instance" "web" {
+  for_each = local.instances
+  subnet_id = each.value.subnet_id
+}`,
+			Expected: helper.Issues{
+				{
+					Rule: NewTerraformDynamicAttributeNotationRule(),
+					Message: "Must use bracket notation [] for dynamic attributes",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 4, Column: 15},
+						End:      hcl.Pos{Line: 4, Column: 35},
+					},
+				},
+			},
+			Fixed: `
+resource "aws_instance" "web" {
+  for_each  = local.instances
+  subnet_id = each.value["subnet_id"]
+}`,
+		},
+		{
+			Name: "valid bracket notation in for_each",
+			Content: `
+resource "aws_instance" "web" {
+  for_each = local.instances
+  subnet_id = each.value["subnet_id"]
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "dot notation in for expression",
+			Content: `
+locals {
+  ips = [for instance in aws_instance.web : instance.private_ip]
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDynamicAttributeNotationRule(),
+					Message: "Must use bracket notation [] for dynamic attributes",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 50},
+						End:      hcl.Pos{Line: 3, Column: 70},
+					},
+				},
+			},
+			Fixed: `
+locals {
+  ips = [for instance in aws_instance.web : instance["private_ip"]]
+}`,
+		},
+		{
+			Name: "dot notation in count",
+			Content: `
+resource "aws_instance" "web" {
+  count = 2
+  subnet_id = aws_subnet.main[count.index].id
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformDynamicAttributeNotationRule(),
+					Message: "Must use bracket notation [] for dynamic attributes",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 4, Column: 31},
+						End:      hcl.Pos{Line: 4, Column: 42},
+					},
+				},
+			},
+			Fixed: `
+resource "aws_instance" "web" {
+  count = 2
+  subnet_id = aws_subnet.main[count.index]["id"]
+}`,
+		},
+	}
+
+	rule := NewTerraformDynamicAttributeNotationRule()
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"config.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+			want := map[string]string{}
+			if tc.Fixed != "" {
+				want["config.tf"] = tc.Fixed
+			}
+			helper.AssertChanges(t, want, runner.Changes())
+		})
+	}
+}

--- a/rules/terraform_static_attribute_notation.go
+++ b/rules/terraform_static_attribute_notation.go
@@ -1,0 +1,131 @@
+package rules
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-terraform/project"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TerraformStaticAttributeNotationRule checks if dot notation is used in static contexts
+type TerraformStaticAttributeNotationRule struct {
+	tflint.DefaultRule
+}
+
+// NewTerraformStaticAttributeNotationRule returns a new rule
+func NewTerraformStaticAttributeNotationRule() *TerraformStaticAttributeNotationRule {
+	return &TerraformStaticAttributeNotationRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformStaticAttributeNotationRule) Name() string {
+	return "terraform_static_attribute_notation"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformStaticAttributeNotationRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *TerraformStaticAttributeNotationRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *TerraformStaticAttributeNotationRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check walks all expressions and emit issues if bracket notation is found in static contexts
+func (r *TerraformStaticAttributeNotationRule) Check(runner tflint.Runner) error {
+	path, err := runner.GetModulePath()
+	if err != nil {
+		return err
+	}
+	if !path.IsRoot() {
+		// This rule does not evaluate child modules
+		return nil
+	}
+
+	diags := runner.WalkExpressions(tflint.ExprWalkFunc(func(expr hcl.Expression) hcl.Diagnostics {
+		if !isStaticContext(expr) {
+			return nil
+		}
+
+		if attr, ok := expr.(*hclsyntax.ScopeTraversalExpr); ok {
+			hasStaticIndex := false
+			for _, traverser := range attr.Traversal {
+				if t, ok := traverser.(hcl.TraverseIndex); ok {
+					// Check if the index is a string literal
+					if t.Key.Type().IsPrimitiveType() && t.Key.Type().Equals(cty.String) {
+						hasStaticIndex = true
+						break
+					}
+				}
+			}
+
+			if hasStaticIndex {
+				if err := runner.EmitIssueWithFix(
+					r,
+					"Must use dot notation for static attributes",
+					expr.Range(),
+					func(f tflint.Fixer) error {
+						var result string
+						if root, ok := attr.Traversal[0].(hcl.TraverseRoot); ok {
+							result = root.Name
+						}
+						for i := 1; i < len(attr.Traversal); i++ {
+							if trav, ok := attr.Traversal[i].(hcl.TraverseAttr); ok {
+								result += "." + trav.Name
+							} else if trav, ok := attr.Traversal[i].(hcl.TraverseIndex); ok {
+								if trav.Key.Type().IsPrimitiveType() && trav.Key.Type().Equals(cty.String) {
+									result += "." + trav.Key.AsString()
+								} else {
+									result += "[" + trav.Key.AsString() + "]"
+								}
+							}
+						}
+						return f.ReplaceText(expr.Range(), result)
+					},
+				); err != nil {
+					return hcl.Diagnostics{
+						{
+							Severity: hcl.DiagError,
+							Summary:  "failed to call EmitIssueWithFix()",
+							Detail:   err.Error(),
+						},
+					}
+				}
+			}
+		}
+		return nil
+	}))
+
+	if diags.HasErrors() {
+		return diags
+	}
+	return nil
+}
+
+func isStaticContext(expr hcl.Expression) bool {
+	// Check if we're inside a dynamic context
+	vars := expr.Variables()
+	for _, v := range vars {
+		if len(v) > 0 {
+			root, ok := v[0].(hcl.TraverseRoot)
+			if ok && (root.Name == "each" || root.Name == "count") {
+				return false
+			}
+		}
+	}
+
+	// Check parent context
+	switch expr.(type) {
+	case *hclsyntax.ForExpr, *hclsyntax.SplatExpr:
+		return false
+	}
+
+	return true
+}

--- a/rules/terraform_static_attribute_notation_test.go
+++ b/rules/terraform_static_attribute_notation_test.go
@@ -1,0 +1,96 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_TerraformStaticAttributeNotationRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+		Fixed    string
+	}{
+		{
+			Name: "bracket notation in static context",
+			Content: `resource "aws_instance" "web" {
+  instance_type = var.instance["type"]
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformStaticAttributeNotationRule(),
+					Message: "Must use dot notation for static attributes",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 2, Column: 19},
+						End:      hcl.Pos{Line: 2, Column: 39},
+					},
+				},
+			},
+			Fixed: `resource "aws_instance" "web" {
+  instance_type = var.instance.type
+}`,
+		},
+		{
+			Name: "dot notation in static context (valid)",
+			Content: `resource "aws_instance" "web" {
+  instance_type = var.instance.type
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "bracket notation with variable index (valid)",
+			Content: `resource "aws_instance" "web" {
+  instance_type = var.instance[var.env]
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "bracket notation with number index (valid)",
+			Content: `resource "aws_instance" "web" {
+  instance_type = var.instance[0]
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "multiple static attributes with bracket notation",
+			Content: `resource "aws_instance" "web" {
+  instance_type = var.instance["type"]["size"]
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformStaticAttributeNotationRule(),
+					Message: "Must use dot notation for static attributes",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 2, Column: 19},
+						End:      hcl.Pos{Line: 2, Column: 47},
+					},
+				},
+			},
+			Fixed: `resource "aws_instance" "web" {
+  instance_type = var.instance.type.size
+}`,
+		},
+	}
+
+	rule := NewTerraformStaticAttributeNotationRule()
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"config.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+			if tc.Fixed != "" {
+				helper.AssertChanges(t, map[string]string{"config.tf": tc.Fixed}, runner.Changes())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added rules:

- `terraform_dynamic_attribute_notation`: Enforces the use of bracket notation for dynamic attribute access. This rule detects dot notation in dynamic contexts (e.g. `for_each` blocks, for expressions, count-related expressions) and auto-fixes these to use bracket notation (e.g. converts `each.value.attribute` to `each.value["attribute"]`).
- `terraform_static_attribute_notation`: Enforces the use of dot notation for static attribute access. When static, literal attribute keys are accessed, the rule ensures that bracket notation is converted to a cleaner dot notation (e.g. converts `var.instance["type"]` to `var.instance.type`).

Both rules include tests and automatic fixers.

Documentation for both rules has been created, the rule list README was also updated.

The urge for this rule arose when some engineers started using VSCode to write tf configs and that resulted in errors in Jetbrains IDEs using the official Terraform plugin. See:
![image](https://github.com/user-attachments/assets/380578fb-ecfe-475c-934a-93407195c510)
