### PR TITLE
Add rule that forces nullable field for variables

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -21,6 +21,7 @@ All rules are enabled by default, but by setting `preset = "recommended"`, you c
 |[terraform_required_version](terraform_required_version.md)|Disallow `terraform` declarations without require_version|✔|
 |[terraform_standard_module_structure](terraform_standard_module_structure.md)|Ensure that a module complies with the Terraform Standard Module Structure||
 |[terraform_typed_variables](terraform_typed_variables.md)|Disallow `variable` declarations without type|✔|
+|[terraform_nullable_variables](terraform_nullable_variables.md)|Disallow `variable` declarations without `nullable` field||
 |[terraform_unused_declarations](terraform_unused_declarations.md)|Disallow variables, data sources, and locals that are declared but never used|✔|
 |[terraform_unused_required_providers](terraform_unused_required_providers.md)|Check that all `required_providers` are used in the module||
 |[terraform_workspace_remote](terraform_workspace_remote.md)|`terraform.workspace` should not be used with a "remote" backend with remote execution in Terraform v1.0.x|✔|

--- a/docs/rules/terraform_nullable_variables.md
+++ b/docs/rules/terraform_nullable_variables.md
@@ -1,0 +1,36 @@
+# terraform_nullable_variables
+
+Disallow `variable` declarations without `nullable` field.
+
+## Example
+
+```hcl
+variable "no_nullable" {}
+
+variable "enabled" {
+  default     = false
+  description = "This is description"
+  nullable    = false
+  type        = bool
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: `no_nullable` variable has no nullable field (terraform_nullable_variables)
+
+  on template.tf line 1:
+   1: variable "no_nullable" {}
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.11.0/docs/rules/terraform_nullable_variables.md
+```
+
+## Why
+
+`nullable` field is optional and `true` by default. This rule forces explicit setting of the `nullable` field for variables.
+
+## How To Fix
+
+Add a `nullable` field to the variable. See https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values for more details about `nullable`.

--- a/rules/preset.go
+++ b/rules/preset.go
@@ -15,6 +15,7 @@ var PresetRules = map[string][]tflint.Rule{
 		NewTerraformModulePinnedSourceRule(),
 		NewTerraformModuleVersionRule(),
 		NewTerraformNamingConventionRule(),
+		NewTerraformNullableVariablesRule(),
 		NewTerraformRequiredProvidersRule(),
 		NewTerraformRequiredVersionRule(),
 		NewTerraformStandardModuleStructureRule(),

--- a/rules/terraform_nullable_variables.go
+++ b/rules/terraform_nullable_variables.go
@@ -1,0 +1,80 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-terraform/project"
+)
+
+// TerraformNullableVariablesRule checks whether variables have a nullable field declared
+type TerraformNullableVariablesRule struct {
+	tflint.DefaultRule
+}
+
+// NewTerraformNullableVariablesRule returns a new rule
+func NewTerraformNullableVariablesRule() *TerraformNullableVariablesRule {
+	return &TerraformNullableVariablesRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformNullableVariablesRule) Name() string {
+	return "terraform_nullable_variables"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformNullableVariablesRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *TerraformNullableVariablesRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *TerraformNullableVariablesRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether variables have nullable field
+func (r *TerraformNullableVariablesRule) Check(runner tflint.Runner) error {
+	path, err := runner.GetModulePath()
+	if err != nil {
+		return err
+	}
+	if !path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
+	body, err := runner.GetModuleContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type:       "variable",
+				LabelNames: []string{"name"},
+				Body: &hclext.BodySchema{
+					Attributes: []hclext.AttributeSchema{{Name: "nullable"}},
+				},
+			},
+		},
+	}, &tflint.GetModuleContentOption{ExpandMode: tflint.ExpandModeNone})
+	if err != nil {
+		return err
+	}
+
+	for _, variable := range body.Blocks {
+		if _, exists := variable.Body.Attributes["nullable"]; !exists {
+			if err := runner.EmitIssue(
+				r,
+				fmt.Sprintf("`%v` variable has no nullable field", variable.Labels[0]),
+				variable.DefRange,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/rules/terraform_nullable_variables_test.go
+++ b/rules/terraform_nullable_variables_test.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_TerraformNullableVariablesRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		JSON     bool
+		Expected helper.Issues
+	}{
+		{
+			Name: "no nullable",
+			Content: `
+variable "no_nullable" {
+  default = "default"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformNullableVariablesRule(),
+					Message: "`no_nullable` variable has no nullable field",
+					Range: hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 23},
+					},
+				},
+			},
+		},
+		{
+			Name: "nullable true",
+			Content: `
+variable "nullable" {
+  nullable = true
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "nullable false",
+			Content: `
+variable "not_nullable" {
+  nullable = false
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewTerraformNullableVariablesRule()
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			filename := "variables.tf"
+			if tc.JSON {
+				filename += ".json"
+			}
+
+			runner := helper.TestRunner(t, map[string]string{filename: tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}


### PR DESCRIPTION
The rule forces explicit `nullable` field for variable declaration.
https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values

The case when `default = null` but `nullable = false` is not checked, because it is covered by `terraform validate`.