### PR TITLE
Enable Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
See https://github.com/terraform-linters/tflint-ruleset-aws/pull/781

This PR enables Dependabot's auto merge, which includes a branch protection rule that prevents branches from being merged unless tests pass. If I get approval, I'll update the repository config before merging.

I've enabled it on a few ruleset repositories and found it beneficial for us who don't have a lot of time to spend on maintenance, and if the experience is good for you, I'd like to enable it on the TFLint repository as well.