### PR TITLE
`required_providers`: support `ephemeral` resources

### DIFF
--- a/rules/terraform_required_providers_test.go
+++ b/rules/terraform_required_providers_test.go
@@ -65,6 +65,31 @@ resource "random_string" "foo" {
 			},
 		},
 		{
+			Name: "implicit provider - resource",
+			Content: `
+ephemeral "random_string" "foo" {
+  length = 16
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: "Missing version constraint for provider \"random\" in `required_providers`",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 32,
+						},
+					},
+				},
+			},
+		},
+		{
 			Name: "implicit provider - data source",
 			Content: `
 data "template_file" "foo" {
@@ -96,11 +121,11 @@ terraform {
   required_providers {
     template = {
       source  = "hashicorp/template"
-      version = "~> 2" 
+      version = "~> 2"
     }
   }
 }
-provider "template" {} 
+provider "template" {}
 `,
 			Expected: helper.Issues{},
 		},
@@ -112,7 +137,7 @@ terraform {
     template = "~> 2"
   }
 }
-provider "template" {} 
+provider "template" {}
 `,
 			Expected: helper.Issues{
 				{
@@ -154,7 +179,7 @@ terraform {
   }
 }
 
-provider "template" {} 
+provider "template" {}
 `,
 			Expected: helper.Issues{
 				{
@@ -185,7 +210,7 @@ terraform {
   }
 }
 
-provider "template" {} 
+provider "template" {}
 `,
 			Config: `
 rule "terraform_required_providers" {
@@ -207,7 +232,7 @@ terraform {
   }
 }
 
-provider "template" {} 
+provider "template" {}
 `,
 			Expected: helper.Issues{
 				{
@@ -250,7 +275,7 @@ terraform {
   }
 }
 
-provider "template" {} 
+provider "template" {}
 `,
 			Config: `
 rule "terraform_required_providers" {
@@ -270,7 +295,7 @@ terraform {
   }
 }
 
-provider "template" {} 
+provider "template" {}
 `,
 			Expected: helper.Issues{
 				{
@@ -355,7 +380,7 @@ terraform {
 
 provider "template" {
   version = "~> 2"
-} 
+}
 `,
 			Expected: helper.Issues{
 				{
@@ -409,7 +434,7 @@ terraform {
 provider "template" {
   alias   = "foo"
   version = "~> 2"
-} 
+}
 `,
 			Expected: helper.Issues{
 				{

--- a/rules/terraform_unused_required_providers_test.go
+++ b/rules/terraform_unused_required_providers_test.go
@@ -33,6 +33,21 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 			Expected: helper.Issues{},
 		},
 		{
+			Name: "used - ephemeral resource",
+			Content: `
+        terraform {
+          required_providers {
+            null = {
+              source = "hashicorp/null"
+            }
+          }
+        }
+
+        ephemeral "null_resource" "foo" {}
+      `,
+			Expected: helper.Issues{},
+		},
+		{
 			Name: "used - data source",
 			Content: `
 				terraform {
@@ -42,7 +57,7 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 						}
 					}
 				}
-				resource "null_data_source" "foo" {}
+				data "null_data_source" "foo" {}
 			`,
 			Expected: helper.Issues{},
 		},
@@ -56,7 +71,7 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 						}
 					}
 				}
-				resource "null_resource" "foo" {
+				data "null_resource" "foo" {
 					provider = custom-null
 				}
 			`,
@@ -72,7 +87,7 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 						}
 					}
 				}
-				resource "null_data_source" "foo" {
+				data "null_data_source" "foo" {
 					provider = custom-null
 				}
 			`,

--- a/terraform/runner.go
+++ b/terraform/runner.go
@@ -123,6 +123,15 @@ func (r *Runner) GetProviderRefs() (map[string]*ProviderRef, hcl.Diagnostics) {
 				},
 			},
 			{
+				Type:       "ephemeral",
+				LabelNames: []string{"type", "name"},
+				Body: &hclext.BodySchema{
+					Attributes: []hclext.AttributeSchema{
+						{Name: "provider"},
+					},
+				},
+			},
+			{
 				Type:       "data",
 				LabelNames: []string{"type", "name"},
 				Body: &hclext.BodySchema{
@@ -177,9 +186,7 @@ func (r *Runner) GetProviderRefs() (map[string]*ProviderRef, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	for _, block := range body.Blocks {
 		switch block.Type {
-		case "resource":
-			fallthrough
-		case "data":
+		case "resource", "ephemeral", "data":
 			if attr, exists := block.Body.Attributes["provider"]; exists {
 				ref, decodeDiags := decodeProviderRef(attr.Expr, block.DefRange)
 				diags = diags.Extend(decodeDiags)


### PR DESCRIPTION
Adds support for the `ephemeral` resource block type when detecting providers.

https://developer.hashicorp.com/terraform/language/resources/ephemeral

This impacts;

* `required_providers`
* `unused_required_providers`

Also, I fixed a few test cases that were supposed to cover `data` blocks but use `resource` instead.

Closes #251 