### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete regular expression for hostnames

### DIFF
--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -19,7 +19,7 @@ import (
 
 var token = os.Getenv("GITHUB_TOKEN")
 var versionRegexp = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
-var goModRequireSDKRegexp = regexp.MustCompile(`github.com/terraform-linters/tflint-plugin-sdk v(.+)`)
+var goModRequireSDKRegexp = regexp.MustCompile(`github\.com/terraform-linters/tflint-plugin-sdk v(.+)`)
 
 func main() {
 	if err := os.Chdir("../../"); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/terraform-linters/tflint-ruleset-terraform/security/code-scanning/2](https://github.com/terraform-linters/tflint-ruleset-terraform/security/code-scanning/2)

To fix the issue, the dot (`.`) in the regular expression should be escaped to ensure it matches a literal dot rather than any character. This can be done by replacing `.` with `\.`. Additionally, using a raw string literal (enclosed in backticks) avoids the need to double-escape the backslash, making the regular expression more readable. The corrected regular expression will be: `` `github\.com/terraform-linters/tflint-plugin-sdk v(.+)` ``.

The change will be made on line 22 of the file `tools/release/main.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
