### PR TITLE
Remove unneeded repository info from goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,8 +41,6 @@ signs:
       - --yes
 release:
   github:
-    owner: terraform-linters
-    name: tflint-ruleset-terraform
   draft: true
 snapshot:
   version_template: "{{ .Tag }}-dev"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint-ruleset-terraform
 
-go 1.24.1
+go 1.24.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-opa/pull/167