### PR TITLE
`module_pinned_source`: handle directories in path

### DIFF
--- a/rules/terraform_module_pinned_source_test.go
+++ b/rules/terraform_module_pinned_source_test.go
@@ -67,6 +67,32 @@ module "pinned_git" {
 			Expected: helper.Issues{},
 		},
 		{
+			Name: "git module with subdirectory is not pinned",
+			Content: `
+module "unpinned" {
+  source = "git://hashicorp.com/consul.git/subdirectory"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformModulePinnedSourceRule(),
+					Message: "Module source \"git://hashicorp.com/consul.git/subdirectory\" is not pinned",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 57},
+					},
+				},
+			},
+		},
+		{
+			Name: "git module with subdirectory reference is pinned",
+			Content: `
+module "pinned_git" {
+  source = "git://hashicorp.com/consul.git/subdirectory?ref=v1.2.3"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
 			Name: "invalid URL",
 			Content: `
 module "invalid" {
@@ -192,6 +218,76 @@ module "default_git" {
 			Content: `
 module "pinned_git" {
   source = "github.com/hashicorp/consul.git?ref=pinned"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "github module with subdirectory is not pinned",
+			Content: `
+module "unpinned" {
+  source = "github.com/hashicorp/consul.git/subdirectory"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformModulePinnedSourceRule(),
+					Message: "Module source \"github.com/hashicorp/consul.git/subdirectory\" is not pinned",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 58},
+					},
+				},
+			},
+		},
+		{
+			Name: "github module with subdirectory reference is pinned",
+			Content: `
+module "pinned_git" {
+  source = "github.com/hashicorp/consul.git/subdirectory?ref=v1.2.3"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "github module with subdirectory reference is default",
+			Content: `
+module "default_git" {
+  source = "github.com/hashicorp/consul.git/subdirectory?ref=master"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformModulePinnedSourceRule(),
+					Message: "Module source \"github.com/hashicorp/consul.git/subdirectory?ref=master\" uses a default branch as ref (master)",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 69},
+					},
+				},
+			},
+		},
+		{
+			Name: "github module with multiple subdirectories is not pinned",
+			Content: `
+module "unpinned" {
+  source = "github.com/hashicorp/consul.git/directory/subdirectory"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformModulePinnedSourceRule(),
+					Message: "Module source \"github.com/hashicorp/consul.git/directory/subdirectory\" is not pinned",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 68},
+					},
+				},
+			},
+		},
+		{
+			Name: "github module with multiple subdirectories reference is pinned",
+			Content: `
+module "pinned_git" {
+  source = "github.com/hashicorp/consul.git/directory/subdirectory?ref=v1.2.3"
 }`,
 			Expected: helper.Issues{},
 		},


### PR DESCRIPTION
Fixes false positive warnings from `terraform_module_pinned_source` when module sources include subdirectories with ref parameters (e.g., `github.com/org/repo.git/directory?ref=v1.2.3`).

## Issue

The `terraform_module_pinned_source` rule was incorrectly reporting modules with subdirectories and query parameters as unpinned. This occurred because `go-getter` URL-encodes query parameters when they appear after a subdirectory path with a single slash. For example, `github.com/org/repo.git/subdirectory?ref=v1.2.3` becomes `git::https://github.com/org/repo.git//subdirectory%253Fref=v1.2.3` after detection, making the ref parameter inaccessible through standard URL query parsing.

Closes #295

## Changes

- Extracts query parameters from the original module source before calling `getter.Detect()`.
- Merges extracted parameters with any parameters found in the detected URL.
- Adds test cases for single and multiple subdirectory paths with both pinned and unpinned references.