### PR TITLE
`terraform_comment_syntax`: Enforce `#` comment syntax for multiline

### DIFF
--- a/docs/rules/terraform_comment_syntax.md
+++ b/docs/rules/terraform_comment_syntax.md
@@ -7,7 +7,9 @@ Enforce usage of `#` for comments.
 ```hcl
 # Good
 // Bad
-/* Bad */
+/*
+  Bad
+*/
 ```
 
 ```
@@ -22,7 +24,7 @@ Warning: [Fixable] Comments should begin with # (terraform_comment_syntax)
 Warning: [Fixable] Comments should begin with # (terraform_comment_syntax)
 
   on t.tf line 3:
-   3: /* Bad */
+   3: /*
 ```
 
 ## Why
@@ -37,5 +39,5 @@ multiline comments. However `#` is considered idiomatic for both single and mult
 
 Run `tflint --fix` to automatically replace `//` comments and multi-line `/* */` comments with `#` comments.
 
-Single-line `/* */` comments are not auto-fixed because they can appear mid-expression (e.g., `x = 1 /* comment */ + 2`),
-where converting to `#` would comment out the rest of the line. These must be fixed manually.
+Single-line `/* */` comments are ignored because they can appear mid-expression (e.g., `x = 1 /* comment */ + 2`),
+where converting to `#` would comment out the rest of the line.

--- a/rules/terraform_comment_syntax.go
+++ b/rules/terraform_comment_syntax.go
@@ -99,11 +99,10 @@ func (r *TerraformCommentSyntaxRule) emitCommentIssue(runner tflint.Runner, file
 	// /* */ style comments
 	comment := string(token.Bytes)
 
-	// Only autofix multi-line comments. Single-line /* */ comments
-	// may be inline within expressions where replacing with # would
-	// comment out the rest of the line.
+	// Ignore single-line /* */ comments - they may be intentional
+	// inline comments within expressions (e.g., x = 1 /* comment */ + 2)
 	if !strings.Contains(comment, "\n") {
-		return runner.EmitIssue(r, message, token.Range)
+		return nil
 	}
 
 	return runner.EmitIssueWithFix(r, message, token.Range, func(f tflint.Fixer) error {

--- a/rules/terraform_comment_syntax_test.go
+++ b/rules/terraform_comment_syntax_test.go
@@ -52,28 +52,11 @@ variable "foo" {
 			Expected: helper.Issues{},
 		},
 		{
-			// Single-line /* */ comments can appear mid-expression (C-style),
-			// e.g. `x = 1 /* comment */ + 2` evaluates to 3. Autofixing to #
-			// would comment out the rest of the line, changing behavior.
-			Name:    "single-line block comment",
-			Content: `x = 1 /* comment */ + 2`,
-			Expected: helper.Issues{
-				{
-					Rule:    NewTerraformCommentSyntaxRule(),
-					Message: "Comments should begin with #",
-					Range: hcl.Range{
-						Filename: "variables.tf",
-						Start: hcl.Pos{
-							Line:   1,
-							Column: 7,
-						},
-						End: hcl.Pos{
-							Line:   1,
-							Column: 20,
-						},
-					},
-				},
-			},
+			// Single-line /* */ comments are ignored - they may be intentional
+			// inline comments within expressions (e.g., x = 1 /* comment */ + 2)
+			Name:     "single-line block comment",
+			Content:  `x = 1 /* comment */ + 2`,
+			Expected: helper.Issues{},
 		},
 		{
 			Name: "multi-line comment",


### PR DESCRIPTION
I'm not sure if this meets the requirements to be included here, as it's not mentioned in the terraform language reference. However I do think that it's a natural extension of the rule, because it further reinforces the consistency of comment syntax.