### PR TITLE
`terraform_unused_declarations`: detect unused provider aliases

### DIFF
--- a/docs/rules/terraform_unused_declarations.md
+++ b/docs/rules/terraform_unused_declarations.md
@@ -1,6 +1,6 @@
 # terraform_unused_declarations
 
-Disallow variables, data sources, and locals that are declared but never used.
+Disallow variables, data sources, locals, and provider aliases that are declared but never used.
 
 > This rule is enabled by "recommended" preset.
 
@@ -28,13 +28,54 @@ Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0
  
 ```
 
+Provider aliases example:
+
+```hcl
+provider "azurerm" {
+  features {}
+  alias           = "test_123"
+  subscription_id = ""
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+  provider = azurerm.test_123
+}
+```
+
+```
+$ tflint
+0 issue(s) found
+```
+
+Without the resource using the aliased provider:
+
+```hcl
+provider "azurerm" {
+  features {}
+  alias           = "test_123"
+  subscription_id = ""
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: provider "azurerm" with alias "test_123" is declared but not used (terraform_unused_declarations)
+
+  on config.tf line 1:
+   1: provider "azurerm" {
+```
+
 ## Why
 
-Terraform will ignore variables and locals that are not used. It will refresh declared data sources regardless of usage. However, unreferenced variables likely indicate either a bug (and should be referenced) or removed code (and should be removed).
+Terraform will ignore variables and locals that are not used. It will refresh declared data sources regardless of usage. However, unreferenced variables and provider aliases likely indicate either a bug (and should be referenced) or removed code (and should be removed).
 
 ## How To Fix
 
-Remove the declaration. For `variable` and `data`, remove the entire block. For a `local` value, remove the attribute from the `locals` block.
+Remove the declaration. For `variable`, `data`, and `provider` (with alias), remove the entire block. For a `local` value, remove the attribute from the `locals` block.
 
 While data sources should generally not have side effects, take greater care when removing them. For example, removing `data "http"` will cause Terraform to no longer perform an HTTP `GET` request during each plan. If a data source is being used for side effects, add an annotation to ignore it:
 


### PR DESCRIPTION
Extends the `terraform_unused_declarations` rule to detect provider blocks with aliases that are never referenced in resources, data sources, or modules. Provider alias must be explicitly referenced so unused declarations can be statically detected. Only default (no alias) provider instances are passed implicitly.

## Changes

- Tracks provider blocks with `alias` attributes in the declarations map
- Detects provider alias references in expressions (e.g., `provider = aws.west`)
- Reports unused provider aliases with auto-fix to remove the provider block
- Only checks providers with aliases, default providers are excluded

## References

Closes https://github.com/terraform-linters/tflint-ruleset-terraform/discussions/303