### PR TITLE
Add test: --only excludes a rule enabled via rule config

### DIFF
--- a/terraform/ruleset_test.go
+++ b/terraform/ruleset_test.go
@@ -191,6 +191,22 @@ func TestApplyConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "rule config enabled + only excludes it",
+			global: &tflint.Config{
+				Rules: map[string]*tflint.RuleConfig{
+					"terraform_comment_syntax": {
+						Name:    "terraform_comment_syntax",
+						Enabled: true,
+					},
+				},
+				Only: []string{"terraform_deprecated_interpolation"},
+			},
+			config: &hclext.BodyContent{},
+			want: []string{
+				"terraform_deprecated_interpolation",
+			},
+		},
+		{
 			name: "disabled by default + preset + rule config",
 			global: &tflint.Config{
 				Rules: map[string]*tflint.RuleConfig{


### PR DESCRIPTION
## What

Add a `TestApplyConfig` case in `terraform/ruleset_test.go` asserting that when
a rule is explicitly enabled via a `rule` config block, a `--only` list that
omits that rule still excludes it. In other words, `--only` takes precedence
over a per-rule `enabled = true`.

## Why

This precedence was not covered by the existing table-driven cases. The new
case pins the behavior so a future regression is caught by the test suite.
