### PR TITLE
Fix null/missing module source aborting the lint run

### DIFF
--- a/docs/rules/terraform_module_pinned_source.md
+++ b/docs/rules/terraform_module_pinned_source.md
@@ -117,15 +117,22 @@ Terraform allows you to source modules from source control repositories. If you 
 
 Pinning to a mutable reference, such as a branch, still allows for unintended breaking changes. Semver style can help avoid this.
 
-## Unresolved sources
+## Dynamic Sources
 
-This rule only checks modules whose `source` resolves to a concrete Git or Mercurial address. It stays silent for modules whose source is not such an address, including:
+Since Terraform v1.15, `source` can be an [expression](https://developer.hashicorp.com/terraform/language/modules/configuration#source-and-version-expressions) built from `const` input variables and local values. This rule evaluates the expression and checks the address it produces.
 
-* an unknown value (for example an unset variable or a sensitive value),
-* a `null` value, and
-* a missing `source` attribute.
+```hcl
+variable "module_source" {
+  type  = string
+  const = true
+}
 
-These are not versionable Git/Mercurial sources, so there is nothing to pin. A missing or otherwise invalid `source` is already reported by `terraform validate`, so this rule does not emit a duplicate diagnostic.
+module "consul" {
+  source = var.module_source
+}
+```
+
+A module is skipped when the expression does not produce an address: the variable may have no value, as above, or its value may be `null`. Terraform reports both during `terraform init`, so this rule stays silent instead of duplicating the error.
 
 ## How To Fix
 

--- a/docs/rules/terraform_module_pinned_source.md
+++ b/docs/rules/terraform_module_pinned_source.md
@@ -117,6 +117,16 @@ Terraform allows you to source modules from source control repositories. If you 
 
 Pinning to a mutable reference, such as a branch, still allows for unintended breaking changes. Semver style can help avoid this.
 
+## Unresolved sources
+
+This rule only checks modules whose `source` resolves to a concrete Git or Mercurial address. It stays silent for modules whose source is not such an address, including:
+
+* an unknown value (for example an unset variable or a sensitive value),
+* a `null` value, and
+* a missing `source` attribute.
+
+These are not versionable Git/Mercurial sources, so there is nothing to pin. A missing or otherwise invalid `source` is already reported by `terraform validate`, so this rule does not emit a duplicate diagnostic.
+
 ## How To Fix
 
 Specify a version pin.  For git repositories, it should not be "master". For Mercurial repositories, it should not be "default".

--- a/docs/rules/terraform_module_shallow_clone.md
+++ b/docs/rules/terraform_module_shallow_clone.md
@@ -30,6 +30,16 @@ When sourcing a Terraform module from a Git repository by tag or branch, enablin
 
 Shallow cloning only includes the most recent commit for a reference. Because it uses the `--branch` argument to `git clone`, it can only be used for named branches and tags, not raw commit IDs.
 
+## Unresolved sources
+
+This rule only checks modules whose `source` resolves to a concrete Git address. It stays silent for modules whose source is not such an address, including:
+
+* an unknown value (for example an unset variable or a sensitive value),
+* a `null` value, and
+* a missing `source` attribute.
+
+These are not Git sources that can be shallow cloned. A missing or otherwise invalid `source` is already reported by `terraform validate`, so this rule does not emit a duplicate diagnostic.
+
 ## How To Fix
 
 Add the `depth=1` query parameter to enable shallow cloning.

--- a/docs/rules/terraform_module_shallow_clone.md
+++ b/docs/rules/terraform_module_shallow_clone.md
@@ -30,15 +30,22 @@ When sourcing a Terraform module from a Git repository by tag or branch, enablin
 
 Shallow cloning only includes the most recent commit for a reference. Because it uses the `--branch` argument to `git clone`, it can only be used for named branches and tags, not raw commit IDs.
 
-## Unresolved sources
+## Dynamic Sources
 
-This rule only checks modules whose `source` resolves to a concrete Git address. It stays silent for modules whose source is not such an address, including:
+Since Terraform v1.15, `source` can be an [expression](https://developer.hashicorp.com/terraform/language/modules/configuration#source-and-version-expressions) built from `const` input variables and local values. This rule evaluates the expression and checks the address it produces.
 
-* an unknown value (for example an unset variable or a sensitive value),
-* a `null` value, and
-* a missing `source` attribute.
+```hcl
+variable "module_source" {
+  type  = string
+  const = true
+}
 
-These are not Git sources that can be shallow cloned. A missing or otherwise invalid `source` is already reported by `terraform validate`, so this rule does not emit a duplicate diagnostic.
+module "consul" {
+  source = var.module_source
+}
+```
+
+A module is skipped when the expression does not produce an address: the variable may have no value, as above, or its value may be `null`. Terraform reports both during `terraform init`, so this rule stays silent instead of duplicating the error.
 
 ## How To Fix
 

--- a/rules/terraform_module_pinned_source.go
+++ b/rules/terraform_module_pinned_source.go
@@ -78,7 +78,7 @@ func (r *TerraformModulePinnedSourceRule) Check(rr tflint.Runner) error {
 }
 
 func (r *TerraformModulePinnedSourceRule) checkModule(runner tflint.Runner, module *terraform.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
-	if !module.SourceKnown {
+	if !module.SourceKnown || module.SourceAttr == nil {
 		return nil
 	}
 

--- a/rules/terraform_module_pinned_source_test.go
+++ b/rules/terraform_module_pinned_source_test.go
@@ -631,6 +631,33 @@ module "dynamic" {
 }`,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "module source is null",
+			Content: `
+module "null_source" {
+  source = null
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "module source with null variable",
+			Content: `
+variable "module_source" {
+  default = null
+}
+
+module "null_var" {
+  source = var.module_source
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "module without source",
+			Content: `
+module "no_source" {
+}`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewTerraformModulePinnedSourceRule()

--- a/rules/terraform_module_pinned_source_test.go
+++ b/rules/terraform_module_pinned_source_test.go
@@ -603,6 +603,8 @@ rule "terraform_module_pinned_source" {
 			Name: "module source with known variable",
 			Content: `
 variable "module_source" {
+  type    = string
+  const   = true
   default = "git://hashicorp.com/consul.git"
 }
 
@@ -615,8 +617,8 @@ module "dynamic" {
 					Message: "Module source \"git://hashicorp.com/consul.git\" is not pinned",
 					Range: hcl.Range{
 						Filename: "module.tf",
-						Start:    hcl.Pos{Line: 7, Column: 12},
-						End:      hcl.Pos{Line: 7, Column: 29},
+						Start:    hcl.Pos{Line: 9, Column: 12},
+						End:      hcl.Pos{Line: 9, Column: 29},
 					},
 				},
 			},
@@ -624,7 +626,10 @@ module "dynamic" {
 		{
 			Name: "module source with unknown variable",
 			Content: `
-variable "module_source" {}
+variable "module_source" {
+  type  = string
+  const = true
+}
 
 module "dynamic" {
   source = var.module_source
@@ -632,21 +637,15 @@ module "dynamic" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "module source is null",
-			Content: `
-module "null_source" {
-  source = null
-}`,
-			Expected: helper.Issues{},
-		},
-		{
 			Name: "module source with null variable",
 			Content: `
 variable "module_source" {
+  type    = string
+  const   = true
   default = null
 }
 
-module "null_var" {
+module "dynamic" {
   source = var.module_source
 }`,
 			Expected: helper.Issues{},
@@ -654,7 +653,7 @@ module "null_var" {
 		{
 			Name: "module without source",
 			Content: `
-module "no_source" {
+module "incomplete" {
 }`,
 			Expected: helper.Issues{},
 		},

--- a/rules/terraform_module_pinned_source_test.go
+++ b/rules/terraform_module_pinned_source_test.go
@@ -650,13 +650,6 @@ module "dynamic" {
 }`,
 			Expected: helper.Issues{},
 		},
-		{
-			Name: "module without source",
-			Content: `
-module "incomplete" {
-}`,
-			Expected: helper.Issues{},
-		},
 	}
 
 	rule := NewTerraformModulePinnedSourceRule()

--- a/rules/terraform_module_shallow_clone.go
+++ b/rules/terraform_module_shallow_clone.go
@@ -69,7 +69,7 @@ func (r *TerraformModuleShallowCloneRule) Check(rr tflint.Runner) error {
 }
 
 func (r *TerraformModuleShallowCloneRule) checkModule(runner tflint.Runner, module *terraform.ModuleCall) error {
-	if !module.SourceKnown {
+	if !module.SourceKnown || module.SourceAttr == nil {
 		return nil
 	}
 

--- a/rules/terraform_module_shallow_clone_test.go
+++ b/rules/terraform_module_shallow_clone_test.go
@@ -251,6 +251,33 @@ module "dynamic" {
 }`,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "module source is null",
+			Content: `
+module "null_source" {
+  source = null
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "module source with null variable",
+			Content: `
+variable "module_source" {
+  default = null
+}
+
+module "null_var" {
+  source = var.module_source
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "module without source",
+			Content: `
+module "no_source" {
+}`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewTerraformModuleShallowCloneRule()

--- a/rules/terraform_module_shallow_clone_test.go
+++ b/rules/terraform_module_shallow_clone_test.go
@@ -270,13 +270,6 @@ module "dynamic" {
 }`,
 			Expected: helper.Issues{},
 		},
-		{
-			Name: "module without source",
-			Content: `
-module "incomplete" {
-}`,
-			Expected: helper.Issues{},
-		},
 	}
 
 	rule := NewTerraformModuleShallowCloneRule()

--- a/rules/terraform_module_shallow_clone_test.go
+++ b/rules/terraform_module_shallow_clone_test.go
@@ -223,6 +223,8 @@ module "short_branch_name" {
 			Name: "module source with known variable",
 			Content: `
 variable "module_source" {
+  type    = string
+  const   = true
   default = "github.com/hashicorp/consul?ref=v1.0.0"
 }
 
@@ -235,8 +237,8 @@ module "dynamic" {
 					Message: `Module source "github.com/hashicorp/consul?ref=v1.0.0" should enable shallow cloning by adding "depth=1" parameter`,
 					Range: hcl.Range{
 						Filename: "module.tf",
-						Start:    hcl.Pos{Line: 7, Column: 12},
-						End:      hcl.Pos{Line: 7, Column: 29},
+						Start:    hcl.Pos{Line: 9, Column: 12},
+						End:      hcl.Pos{Line: 9, Column: 29},
 					},
 				},
 			},
@@ -244,7 +246,10 @@ module "dynamic" {
 		{
 			Name: "module source with unknown variable",
 			Content: `
-variable "module_source" {}
+variable "module_source" {
+  type  = string
+  const = true
+}
 
 module "dynamic" {
   source = var.module_source
@@ -252,21 +257,15 @@ module "dynamic" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "module source is null",
-			Content: `
-module "null_source" {
-  source = null
-}`,
-			Expected: helper.Issues{},
-		},
-		{
 			Name: "module source with null variable",
 			Content: `
 variable "module_source" {
+  type    = string
+  const   = true
   default = null
 }
 
-module "null_var" {
+module "dynamic" {
   source = var.module_source
 }`,
 			Expected: helper.Issues{},
@@ -274,7 +273,7 @@ module "null_var" {
 		{
 			Name: "module without source",
 			Content: `
-module "no_source" {
+module "incomplete" {
 }`,
 			Expected: helper.Issues{},
 		},


### PR DESCRIPTION
## What

Two rules abort the entire ruleset run when a module's `source` is null,
empty, or absent:

- `terraform_module_pinned_source` (default / `recommended` preset)
- `terraform_module_shallow_clone` (opt-in)

Three configurations trigger it in each:

- `source = null` (literal null)
- `source = var.x` where `var.x` has `default = null`
- a `module` block with no `source` attribute

All three decode to `Source == ""`, `SourceKnown == true`, `SourceAttr == nil`
Each rule's guard only skipped **unknown** sources, so these fell through to
`getter.Detect("", …)`, which returns `invalid source string:`. Because
`Check` returns that as an error (not an issue), tflint reports
`Failed to check ruleset; ... invalid source string:` and discards every
rule's findings across the whole configuration. (For the default-enabled
`terraform_module_pinned_source`, a single `source = null` anywhere breaks
the whole run.)

## Fix

Extend each guard to also skip when there is no source attribute:

```go
if !module.SourceKnown || module.SourceAttr == nil {
    return nil
}
```

`SourceAttr == nil` is the reliable signal for "known, but no real source
string": it is nil for an omitted `source` and is explicitly nilled for a null
value in `decodeModuleCall`. This makes null/empty/missing sources behave the
same as the already-handled unknown-variable case (silently skipped) rather
than crashing the run. Terraform core already reports a missing/invalid
required `source`, so neither rule duplicates that.

## Tests

Added three regression cases to each rule's test table (`source = null`,
null-default variable, missing `source`), each expecting no issues. They fail
before the fix (`invalid source string:`) and pass after it. `go test ./...`
is green.

## Docs

Added an "Unresolved sources" note to both rules' docs explaining why these
sources are skipped.
