### PR TITLE
Resolve module source and version statically, skip unresolvable calls

### DIFF
--- a/docs/rules/terraform_module_pinned_source.md
+++ b/docs/rules/terraform_module_pinned_source.md
@@ -117,6 +117,23 @@ Terraform allows you to source modules from source control repositories. If you 
 
 Pinning to a mutable reference, such as a branch, still allows for unintended breaking changes. Semver style can help avoid this.
 
+## Dynamic Sources
+
+Since Terraform v1.15, `source` can be an [expression](https://developer.hashicorp.com/terraform/language/modules/configuration#source-and-version-expressions) built from `const` input variables and local values. This rule evaluates the expression and checks the address it produces.
+
+```hcl
+variable "module_source" {
+  type  = string
+  const = true
+}
+
+module "consul" {
+  source = var.module_source
+}
+```
+
+A module is skipped when the expression does not produce an address: the variable may have no value (as above) or a `null` value. Terraform reports both during `terraform init`, so this rule does not duplicate the error.
+
 ## How To Fix
 
 Specify a version pin.  For git repositories, it should not be "master". For Mercurial repositories, it should not be "default".

--- a/docs/rules/terraform_module_shallow_clone.md
+++ b/docs/rules/terraform_module_shallow_clone.md
@@ -30,6 +30,23 @@ When sourcing a Terraform module from a Git repository by tag or branch, enablin
 
 Shallow cloning only includes the most recent commit for a reference. Because it uses the `--branch` argument to `git clone`, it can only be used for named branches and tags, not raw commit IDs.
 
+## Dynamic Sources
+
+Since Terraform v1.15, `source` can be an [expression](https://developer.hashicorp.com/terraform/language/modules/configuration#source-and-version-expressions) built from `const` input variables and local values. This rule evaluates the expression and checks the address it produces.
+
+```hcl
+variable "module_source" {
+  type  = string
+  const = true
+}
+
+module "consul" {
+  source = var.module_source
+}
+```
+
+A module is skipped when the expression does not produce an address: the variable may have no value (as above) or a `null` value. Terraform reports both during `terraform init`, so this rule does not duplicate the error.
+
 ## How To Fix
 
 Add the `depth=1` query parameter to enable shallow cloning.

--- a/docs/rules/terraform_module_version.md
+++ b/docs/rules/terraform_module_version.md
@@ -94,6 +94,10 @@ Depending on your workflow, you may want to enforce that modules specify an _exa
 
 Keep in mind that the module may include further child modules, which have their own version constraints. TFLint _does not_ check version constraints set in child modules. **Enabling this rule cannot guarantee that `terraform init` will be deterministic**. Use [Terraform dependency lock files](https://developer.hashicorp.com/terraform/language/files/dependency-lock) to ensure that Terraform will always use the same version of all modules (and providers) until you explicitly update them.
 
+## Dynamic Sources and Versions
+
+Since Terraform v1.15, `source` and `version` can be [expressions](https://developer.hashicorp.com/terraform/language/modules/configuration#source-and-version-expressions) built from `const` input variables and local values. This rule evaluates them and checks the results. A module is skipped when its source or version does not resolve, such as when a `const` variable has no value. Terraform already errors on this during `terraform init`. A `null` version is different: Terraform treats it as unset, so a registry module with a `null` version is still reported.
+
 ## How To Fix
 
 Specify a `version`. If `exact = true`, this must be an exact version.

--- a/rules/terraform_module_pinned_source.go
+++ b/rules/terraform_module_pinned_source.go
@@ -78,10 +78,6 @@ func (r *TerraformModulePinnedSourceRule) Check(rr tflint.Runner) error {
 }
 
 func (r *TerraformModulePinnedSourceRule) checkModule(runner tflint.Runner, module *terraform.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
-	if !module.SourceKnown {
-		return nil
-	}
-
 	// Extract query parameters from the original source before calling getter.Detect()
 	// because go-getter may URL-encode them when there's a subdirectory path
 	originalQuery := url.Values{}

--- a/rules/terraform_module_pinned_source_test.go
+++ b/rules/terraform_module_pinned_source_test.go
@@ -603,6 +603,8 @@ rule "terraform_module_pinned_source" {
 			Name: "module source with known variable",
 			Content: `
 variable "module_source" {
+  type    = string
+  const   = true
   default = "git://hashicorp.com/consul.git"
 }
 
@@ -615,8 +617,8 @@ module "dynamic" {
 					Message: "Module source \"git://hashicorp.com/consul.git\" is not pinned",
 					Range: hcl.Range{
 						Filename: "module.tf",
-						Start:    hcl.Pos{Line: 7, Column: 12},
-						End:      hcl.Pos{Line: 7, Column: 29},
+						Start:    hcl.Pos{Line: 9, Column: 12},
+						End:      hcl.Pos{Line: 9, Column: 29},
 					},
 				},
 			},
@@ -624,7 +626,24 @@ module "dynamic" {
 		{
 			Name: "module source with unknown variable",
 			Content: `
-variable "module_source" {}
+variable "module_source" {
+  type  = string
+  const = true
+}
+
+module "dynamic" {
+  source = var.module_source
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "module source with null variable",
+			Content: `
+variable "module_source" {
+  type    = string
+  const   = true
+  default = null
+}
 
 module "dynamic" {
   source = var.module_source

--- a/rules/terraform_module_shallow_clone.go
+++ b/rules/terraform_module_shallow_clone.go
@@ -69,10 +69,6 @@ func (r *TerraformModuleShallowCloneRule) Check(rr tflint.Runner) error {
 }
 
 func (r *TerraformModuleShallowCloneRule) checkModule(runner tflint.Runner, module *terraform.ModuleCall) error {
-	if !module.SourceKnown {
-		return nil
-	}
-
 	filename := module.DefRange.Filename
 	source, err := getter.Detect(module.Source, filepath.Dir(filename), []getter.Detector{
 		// https://github.com/hashicorp/terraform/blob/51b0aee36cc2145f45f5b04051a01eb6eb7be8bf/internal/getmodules/getter.go#L30-L52

--- a/rules/terraform_module_shallow_clone_test.go
+++ b/rules/terraform_module_shallow_clone_test.go
@@ -223,6 +223,8 @@ module "short_branch_name" {
 			Name: "module source with known variable",
 			Content: `
 variable "module_source" {
+  type    = string
+  const   = true
   default = "github.com/hashicorp/consul?ref=v1.0.0"
 }
 
@@ -235,8 +237,8 @@ module "dynamic" {
 					Message: `Module source "github.com/hashicorp/consul?ref=v1.0.0" should enable shallow cloning by adding "depth=1" parameter`,
 					Range: hcl.Range{
 						Filename: "module.tf",
-						Start:    hcl.Pos{Line: 7, Column: 12},
-						End:      hcl.Pos{Line: 7, Column: 29},
+						Start:    hcl.Pos{Line: 9, Column: 12},
+						End:      hcl.Pos{Line: 9, Column: 29},
 					},
 				},
 			},
@@ -244,7 +246,24 @@ module "dynamic" {
 		{
 			Name: "module source with unknown variable",
 			Content: `
-variable "module_source" {}
+variable "module_source" {
+  type  = string
+  const = true
+}
+
+module "dynamic" {
+  source = var.module_source
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "module source with null variable",
+			Content: `
+variable "module_source" {
+  type    = string
+  const   = true
+  default = null
+}
 
 module "dynamic" {
   source = var.module_source

--- a/rules/terraform_module_version.go
+++ b/rules/terraform_module_version.go
@@ -74,10 +74,6 @@ func (r *TerraformModuleVersionRule) Check(rr tflint.Runner) error {
 }
 
 func (r *TerraformModuleVersionRule) checkModule(runner tflint.Runner, module *terraform.ModuleCall, config TerraformModuleVersionRuleConfig) error {
-	if !module.SourceKnown {
-		return nil
-	}
-
 	_, err := tfaddr.ParseModuleSource(module.Source)
 	if err != nil {
 		// If parsing fails, the source does not expect to specify a version,
@@ -90,10 +86,6 @@ func (r *TerraformModuleVersionRule) checkModule(runner tflint.Runner, module *t
 }
 
 func (r *TerraformModuleVersionRule) checkVersion(runner tflint.Runner, module *terraform.ModuleCall, config TerraformModuleVersionRuleConfig) error {
-	if !module.VersionKnown {
-		return nil
-	}
-
 	if module.Version == nil {
 		return runner.EmitIssue(
 			r,

--- a/rules/terraform_module_version_test.go
+++ b/rules/terraform_module_version_test.go
@@ -179,9 +179,13 @@ module "m" {
 			Name: "with known variables",
 			Content: `
 variable "source" {
+  type    = string
+  const   = true
   default = "ns/name/provider"
 }
 variable "version" {
+  type    = string
+  const   = true
   default = "1.0.0"
 }
 
@@ -195,9 +199,13 @@ module "m" {
 			Name: "with null version variable",
 			Content: `
 variable "source" {
+  type    = string
+  const   = true
   default = "ns/name/provider"
 }
 variable "version" {
+  type    = string
+  const   = true
   default = null
 }
 
@@ -211,8 +219,8 @@ module "m" {
 					Message: `module "m" should specify a version`,
 					Range: hcl.Range{
 						Filename: "module.tf",
-						Start:    hcl.Pos{Line: 9, Column: 1},
-						End:      hcl.Pos{Line: 9, Column: 11},
+						Start:    hcl.Pos{Line: 13, Column: 1},
+						End:      hcl.Pos{Line: 13, Column: 11},
 					},
 				},
 			},
@@ -220,7 +228,10 @@ module "m" {
 		{
 			Name: "with unknown source variable",
 			Content: `
-variable "source" {}
+variable "source" {
+  type  = string
+  const = true
+}
 
 module "m" {
   source  = var.source
@@ -230,7 +241,10 @@ module "m" {
 		{
 			Name: "with unknown version variable",
 			Content: `
-variable "version" {}
+variable "version" {
+  type  = string
+  const = true
+}
 
 module "m" {
   source  = "ns/name/provider"

--- a/terraform/runner.go
+++ b/terraform/runner.go
@@ -21,7 +21,9 @@ func NewRunner(runner tflint.Runner) *Runner {
 	return &Runner{Runner: runner}
 }
 
-// GetModuleCalls returns all "module" blocks, including uncreated module calls.
+// GetModuleCalls returns "module" blocks, including uncreated module calls.
+// Only calls whose source and version statically resolve are returned, since
+// Terraform rejects any other configuration when loading it.
 func (r *Runner) GetModuleCalls() ([]*ModuleCall, hcl.Diagnostics) {
 	calls := []*ModuleCall{}
 	diags := hcl.Diagnostics{}
@@ -53,7 +55,7 @@ func (r *Runner) GetModuleCalls() ([]*ModuleCall, hcl.Diagnostics) {
 	for _, block := range body.Blocks {
 		call, decodeDiags := decodeModuleCall(r, block)
 		diags = diags.Extend(decodeDiags)
-		if decodeDiags.HasErrors() {
+		if decodeDiags.HasErrors() || call == nil {
 			continue
 		}
 		calls = append(calls, call)

--- a/terraform/runner_test.go
+++ b/terraform/runner_test.go
@@ -41,8 +41,7 @@ module "server" {
 						Start:    hcl.Pos{Line: 2, Column: 1},
 						End:      hcl.Pos{Line: 2, Column: 16},
 					},
-					Source:      "./server",
-					SourceKnown: true,
+					Source: "./server",
 					SourceAttr: &hclext.Attribute{
 						Name: "source",
 						Expr: parseExpr(t, `"./server"`, hcl.Pos{Line: 3, Column: 12}),
@@ -57,7 +56,6 @@ module "server" {
 							End:      hcl.Pos{Line: 3, Column: 9},
 						},
 					},
-					VersionKnown: true,
 				},
 			},
 		},
@@ -76,8 +74,7 @@ module "vpc" {
 						Start:    hcl.Pos{Line: 2, Column: 1},
 						End:      hcl.Pos{Line: 2, Column: 13},
 					},
-					Source:      "terraform-aws-modules/vpc/aws",
-					SourceKnown: true,
+					Source: "terraform-aws-modules/vpc/aws",
 					SourceAttr: &hclext.Attribute{
 						Name: "source",
 						Expr: parseExpr(t, `"terraform-aws-modules/vpc/aws"`, hcl.Pos{Line: 3, Column: 13}),
@@ -92,8 +89,7 @@ module "vpc" {
 							End:      hcl.Pos{Line: 3, Column: 9},
 						},
 					},
-					Version:      version.MustConstraints(version.NewConstraint("3.14.2")),
-					VersionKnown: true,
+					Version: version.MustConstraints(version.NewConstraint("3.14.2")),
 					VersionAttr: &hclext.Attribute{
 						Name: "version",
 						Expr: parseExpr(t, `"3.14.2"`, hcl.Pos{Line: 4, Column: 13}),
@@ -115,9 +111,13 @@ module "vpc" {
 			name: "known variables",
 			content: `
 variable "source" {
+  type    = string
+  const   = true
   default = "terraform-aws-modules/vpc/aws"
 }
 variable "version" {
+  type    = string
+  const   = true
   default = "3.14.2"
 }
 
@@ -130,39 +130,37 @@ module "vpc" {
 					Name: "vpc",
 					DefRange: hcl.Range{
 						Filename: "main.tf",
-						Start:    hcl.Pos{Line: 9, Column: 1},
-						End:      hcl.Pos{Line: 9, Column: 13},
+						Start:    hcl.Pos{Line: 13, Column: 1},
+						End:      hcl.Pos{Line: 13, Column: 13},
 					},
-					Source:      "terraform-aws-modules/vpc/aws",
-					SourceKnown: true,
+					Source: "terraform-aws-modules/vpc/aws",
 					SourceAttr: &hclext.Attribute{
 						Name: "source",
-						Expr: parseExpr(t, `var.source`, hcl.Pos{Line: 10, Column: 13}),
+						Expr: parseExpr(t, `var.source`, hcl.Pos{Line: 14, Column: 13}),
 						Range: hcl.Range{
 							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 10, Column: 3},
-							End:      hcl.Pos{Line: 10, Column: 23},
+							Start:    hcl.Pos{Line: 14, Column: 3},
+							End:      hcl.Pos{Line: 14, Column: 23},
 						},
 						NameRange: hcl.Range{
 							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 10, Column: 3},
-							End:      hcl.Pos{Line: 10, Column: 9},
+							Start:    hcl.Pos{Line: 14, Column: 3},
+							End:      hcl.Pos{Line: 14, Column: 9},
 						},
 					},
-					Version:      version.MustConstraints(version.NewConstraint("3.14.2")),
-					VersionKnown: true,
+					Version: version.MustConstraints(version.NewConstraint("3.14.2")),
 					VersionAttr: &hclext.Attribute{
 						Name: "version",
-						Expr: parseExpr(t, `var.version`, hcl.Pos{Line: 11, Column: 13}),
+						Expr: parseExpr(t, `var.version`, hcl.Pos{Line: 15, Column: 13}),
 						Range: hcl.Range{
 							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 11, Column: 3},
-							End:      hcl.Pos{Line: 11, Column: 24},
+							Start:    hcl.Pos{Line: 15, Column: 3},
+							End:      hcl.Pos{Line: 15, Column: 24},
 						},
 						NameRange: hcl.Range{
 							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 11, Column: 3},
-							End:      hcl.Pos{Line: 11, Column: 10},
+							Start:    hcl.Pos{Line: 15, Column: 3},
+							End:      hcl.Pos{Line: 15, Column: 10},
 						},
 					},
 				},
@@ -171,127 +169,46 @@ module "vpc" {
 		{
 			name: "unknown variables",
 			content: `
-variable "source" {}
-variable "version" {}
-
-module "vpc" {
-  source  = var.source
-  version = var.version
-}`,
-			want: []*ModuleCall{
-				{
-					Name: "vpc",
-					DefRange: hcl.Range{
-						Filename: "main.tf",
-						Start:    hcl.Pos{Line: 5, Column: 1},
-						End:      hcl.Pos{Line: 5, Column: 13},
-					},
-					Source:      "",
-					SourceKnown: false,
-					SourceAttr: &hclext.Attribute{
-						Name: "source",
-						Expr: parseExpr(t, `var.source`, hcl.Pos{Line: 6, Column: 13}),
-						Range: hcl.Range{
-							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 6, Column: 3},
-							End:      hcl.Pos{Line: 6, Column: 23},
-						},
-						NameRange: hcl.Range{
-							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 6, Column: 3},
-							End:      hcl.Pos{Line: 6, Column: 9},
-						},
-					},
-					Version:      nil,
-					VersionKnown: false,
-					VersionAttr: &hclext.Attribute{
-						Name: "version",
-						Expr: parseExpr(t, `var.version`, hcl.Pos{Line: 7, Column: 13}),
-						Range: hcl.Range{
-							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 7, Column: 3},
-							End:      hcl.Pos{Line: 7, Column: 24},
-						},
-						NameRange: hcl.Range{
-							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 7, Column: 3},
-							End:      hcl.Pos{Line: 7, Column: 10},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "sensitive variables",
-			content: `
 variable "source" {
-  default   = "terraform-aws-modules/vpc/aws"
-  sensitive = true
+  type  = string
+  const = true
 }
 variable "version" {
-  default   = "3.14.2"
-  sensitive = true
+  type  = string
+  const = true
 }
 
 module "vpc" {
   source  = var.source
   version = var.version
 }`,
-			want: []*ModuleCall{
-				{
-					Name: "vpc",
-					DefRange: hcl.Range{
-						Filename: "main.tf",
-						Start:    hcl.Pos{Line: 11, Column: 1},
-						End:      hcl.Pos{Line: 11, Column: 13},
-					},
-					Source:      "",
-					SourceKnown: false,
-					SourceAttr: &hclext.Attribute{
-						Name: "source",
-						Expr: parseExpr(t, `var.source`, hcl.Pos{Line: 12, Column: 13}),
-						Range: hcl.Range{
-							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 12, Column: 3},
-							End:      hcl.Pos{Line: 12, Column: 23},
-						},
-						NameRange: hcl.Range{
-							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 12, Column: 3},
-							End:      hcl.Pos{Line: 12, Column: 9},
-						},
-					},
-					Version:      nil,
-					VersionKnown: false,
-					VersionAttr: &hclext.Attribute{
-						Name: "version",
-						Expr: parseExpr(t, `var.version`, hcl.Pos{Line: 13, Column: 13}),
-						Range: hcl.Range{
-							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 13, Column: 3},
-							End:      hcl.Pos{Line: 13, Column: 24},
-						},
-						NameRange: hcl.Range{
-							Filename: "main.tf",
-							Start:    hcl.Pos{Line: 13, Column: 3},
-							End:      hcl.Pos{Line: 13, Column: 10},
-						},
-					},
-				},
-			},
+			want: []*ModuleCall{},
 		},
 		{
-			name: "null variables",
+			name: "null source variable",
 			content: `
 variable "source" {
-  default = null
-}
-variable "version" {
+  type    = string
+  const   = true
   default = null
 }
 
 module "vpc" {
-  source  = var.source
+  source = var.source
+}`,
+			want: []*ModuleCall{},
+		},
+		{
+			name: "null version variable",
+			content: `
+variable "version" {
+  type    = string
+  const   = true
+  default = null
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
   version = var.version
 }`,
 			want: []*ModuleCall{
@@ -299,15 +216,39 @@ module "vpc" {
 					Name: "vpc",
 					DefRange: hcl.Range{
 						Filename: "main.tf",
-						Start:    hcl.Pos{Line: 9, Column: 1},
-						End:      hcl.Pos{Line: 9, Column: 13},
+						Start:    hcl.Pos{Line: 8, Column: 1},
+						End:      hcl.Pos{Line: 8, Column: 13},
 					},
-					Source:       "",
-					SourceKnown:  true,
-					SourceAttr:   nil,
-					Version:      nil,
-					VersionKnown: true,
-					VersionAttr:  nil,
+					Source: "terraform-aws-modules/vpc/aws",
+					SourceAttr: &hclext.Attribute{
+						Name: "source",
+						Expr: parseExpr(t, `"terraform-aws-modules/vpc/aws"`, hcl.Pos{Line: 9, Column: 13}),
+						Range: hcl.Range{
+							Filename: "main.tf",
+							Start:    hcl.Pos{Line: 9, Column: 3},
+							End:      hcl.Pos{Line: 9, Column: 44},
+						},
+						NameRange: hcl.Range{
+							Filename: "main.tf",
+							Start:    hcl.Pos{Line: 9, Column: 3},
+							End:      hcl.Pos{Line: 9, Column: 9},
+						},
+					},
+					Version: nil,
+					VersionAttr: &hclext.Attribute{
+						Name: "version",
+						Expr: parseExpr(t, `var.version`, hcl.Pos{Line: 10, Column: 13}),
+						Range: hcl.Range{
+							Filename: "main.tf",
+							Start:    hcl.Pos{Line: 10, Column: 3},
+							End:      hcl.Pos{Line: 10, Column: 24},
+						},
+						NameRange: hcl.Range{
+							Filename: "main.tf",
+							Start:    hcl.Pos{Line: 10, Column: 3},
+							End:      hcl.Pos{Line: 10, Column: 10},
+						},
+					},
 				},
 			},
 		},

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -6,82 +6,80 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // ModuleCall represents a "module" block.
 type ModuleCall struct {
-	Name         string
-	DefRange     hcl.Range
-	Source       string
-	SourceKnown  bool
-	SourceAttr   *hclext.Attribute
-	Version      version.Constraints
-	VersionKnown bool
-	VersionAttr  *hclext.Attribute
+	Name        string
+	DefRange    hcl.Range
+	Source      string
+	SourceAttr  *hclext.Attribute
+	Version     version.Constraints
+	VersionAttr *hclext.Attribute
 }
 
+// decodeModuleCall evaluates a module block's source and version, mirroring
+// how Terraform evaluates them when loading the configuration: anything that
+// does not produce a known, non-null string is rejected, except a null
+// version, which is treated as unset. A call Terraform would reject is
+// returned as nil with no diagnostics.
 func decodeModuleCall(runner *Runner, block *hclext.Block) (*ModuleCall, hcl.Diagnostics) {
+	source, exists := block.Body.Attributes["source"]
+	if !exists {
+		return nil, nil
+	}
+
 	module := &ModuleCall{
-		Name:     block.Labels[0],
-		DefRange: block.DefRange,
+		Name:       block.Labels[0],
+		DefRange:   block.DefRange,
+		SourceAttr: source,
 	}
-	diags := hcl.Diagnostics{}
 
-	if source, exists := block.Body.Attributes["source"]; exists {
-		module.SourceAttr = source
-
-		sourceVal, sourceKnown, sourceNull, sourceDiags := evalModuleAttribute(runner, source.Expr)
-		module.Source = sourceVal
-		module.SourceKnown = sourceKnown
-		if sourceNull {
-			module.SourceAttr = nil
-		}
-		diags = diags.Extend(sourceDiags)
-	} else {
-		module.SourceKnown = true
+	sourceVal, sourceDiags := evalModuleAttribute(runner, source.Expr)
+	if sourceDiags.HasErrors() {
+		return nil, sourceDiags
 	}
+	if !sourceVal.IsKnown() || sourceVal.IsMarked() || sourceVal.IsNull() {
+		return nil, nil
+	}
+	module.Source = sourceVal.AsString()
 
 	if versionAttr, exists := block.Body.Attributes["version"]; exists {
 		module.VersionAttr = versionAttr
 
-		versionVal, versionKnown, versionNull, versionDiags := evalModuleAttribute(runner, versionAttr.Expr)
-		diags = diags.Extend(versionDiags)
-		if diags.HasErrors() {
-			return module, diags
+		versionVal, versionDiags := evalModuleAttribute(runner, versionAttr.Expr)
+		if versionDiags.HasErrors() {
+			return nil, versionDiags
+		}
+		if !versionVal.IsKnown() || versionVal.IsMarked() {
+			return nil, nil
+		}
+		if versionVal.IsNull() {
+			return module, nil
 		}
 
-		if !versionKnown {
-			return module, diags
-		}
-		module.VersionKnown = true
-
-		if versionNull {
-			module.VersionAttr = nil
-			return module, diags
-		}
-
-		constraints, err := version.NewConstraint(versionVal)
+		constraints, err := version.NewConstraint(versionVal.AsString())
 		if err != nil {
-			diags = append(diags, &hcl.Diagnostic{
+			return module, hcl.Diagnostics{{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid version constraint",
 				Detail:   "This string does not use correct version constraint syntax.",
 				Subject:  versionAttr.Expr.Range().Ptr(),
-			})
+			}}
 		}
 		module.Version = constraints
-	} else {
-		module.VersionKnown = true
 	}
 
-	return module, diags
+	return module, nil
 }
 
-func evalModuleAttribute(runner *Runner, expr hcl.Expression) (val string, known bool, null bool, diags hcl.Diagnostics) {
-	var ret cty.Value
-	err := runner.EvaluateExpr(expr, &ret, nil)
-	if err != nil {
-		return "", false, false, hcl.Diagnostics{{
+// evalModuleAttribute evaluates an expression to a string-typed cty.Value,
+// which may be unknown, marked, or null.
+func evalModuleAttribute(runner *Runner, expr hcl.Expression) (cty.Value, hcl.Diagnostics) {
+	var val cty.Value
+	if err := runner.EvaluateExpr(expr, &val, nil); err != nil {
+		return cty.NilVal, hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  "Failed to evaluate expression",
 			Detail:   err.Error(),
@@ -89,15 +87,9 @@ func evalModuleAttribute(runner *Runner, expr hcl.Expression) (val string, known
 		}}
 	}
 
-	// sensitive values are treated as unknown
-	if !ret.IsKnown() || ret.IsMarked() {
-		return "", false, false, nil
-	}
-	if ret.IsNull() {
-		return "", true, true, nil
-	}
-	if ret.Type() != cty.String {
-		return "", true, false, hcl.Diagnostics{{
+	converted, err := convert.Convert(val, cty.String)
+	if err != nil {
+		return cty.NilVal, hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  "Expected a string",
 			Detail:   "The expression should evaluate to a string.",
@@ -105,7 +97,7 @@ func evalModuleAttribute(runner *Runner, expr hcl.Expression) (val string, known
 		}}
 	}
 
-	return ret.AsString(), true, false, nil
+	return converted, nil
 }
 
 // Local represents a single entry from a "locals" block.


### PR DESCRIPTION
A module call whose `source` evaluates to null currently decodes to `Source == ""`, which `terraform_module_pinned_source` and `terraform_module_shallow_clone` pass to `getter.Detect`. That errors and aborts the entire run. #367 fixes the crash with per-rule guards; this PR removes the state those guards defend against. Closes #367.

The underlying problem is the shape #356 introduced: unknown and null sources and versions are modeled as first-class states (`SourceKnown`, `VersionKnown`, a nil `SourceAttr`) that every rule must remember to guard against, and forgetting a guard is a crash. Terraform 1.15's actual contract is narrower. Per the [source and version expressions documentation](https://developer.hashicorp.com/terraform/language/modules/configuration#source-and-version-expressions), these attributes may only reference `const` variables and locals built from them, are evaluated at configuration load, and anything that does not produce a known, non-null string is an init error. The one exception is a null `version`, which Terraform treats as unset. So in any configuration that survives `terraform init`, every module call has a concrete source string.

This PR mirrors that contract. `decodeModuleCall` evaluates both expressions and `GetModuleCalls` drops any call that does not statically resolve, so rules only ever see calls with a concrete source and need no guards. `ModuleCall` drops the `SourceKnown` and `VersionKnown` fields. A null `version` keeps the call with `Version` unset, so `terraform_module_version` still reports a registry module with `version = null`. No new lint covers non-const references in these attributes: `terraform init` already reports them, and tflint just evaluates.

Test fixtures now declare the referenced variables with `type = string` and `const = true`, since Terraform rejects anything else at load. The literal `source = null`, missing-`source`, and sensitive-variable cases are gone for the same reason: a missing source never loads, and `const` and `sensitive` are mutually exclusive. A `const` variable with a null default stays as a regression case for the crash.
